### PR TITLE
feat(admin) 어드민 대시보드 및 마크다운 에디터 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 
 #cursor
 .cursorrules
+.cursor/rules/requirements.mdc

--- a/app/admin/editor/page.module.scss
+++ b/app/admin/editor/page.module.scss
@@ -34,7 +34,7 @@
 .title {
   font-size: 2.5rem;
   font-weight: 700;
-  margin-bottom: 1rem;
+  margin: 0;
   color: #1F1F1F;
   position: relative;
   padding-left: 1rem;
@@ -48,6 +48,61 @@
     height: 70%;
     background: #644AC9;
     border-radius: 2px;
+  }
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.saveButton {
+  padding: 0.75rem 1.5rem;
+  background-color: #644AC9;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  
+  &:hover {
+    background-color: #5038af;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+  }
+  
+  &:disabled {
+    background-color: #e2e8f0;
+    color: #94a3b8;
+    cursor: not-allowed;
+  }
+}
+
+.editorForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.metadataSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.metadataColumns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -76,6 +131,16 @@
   
   .title {
     font-size: 2rem;
+  }
+  
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  
+  .actions {
+    width: 100%;
+    justify-content: flex-end;
   }
 }
 

--- a/app/admin/editor/page.module.scss
+++ b/app/admin/editor/page.module.scss
@@ -132,7 +132,7 @@
 
 .titleSection {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 1rem;
   width: 100%;
   

--- a/app/admin/editor/page.module.scss
+++ b/app/admin/editor/page.module.scss
@@ -1,11 +1,7 @@
 .container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 42px 2rem;
   width: 100%;
-  display: flex;
-  flex-direction: column;
-  position: relative;
+  margin: 0 auto;
+  padding: 1rem;
 }
 
 .header {
@@ -85,7 +81,7 @@
 .editorForm {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
   width: 100%;
 }
 
@@ -123,30 +119,54 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
 }
 
+.titleSection {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+.categoryWrapper {
+  min-width: 200px;
+  width: auto;
+  
+  @media (max-width: 768px) {
+    width: 100%;
+  }
+}
+
+.footerSection {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+  
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+}
+
 // 반응형 스타일
 @media (max-width: 768px) {
   .container {
-    padding: 32px 1.5rem;
+    padding: 0.75rem;
   }
   
-  .title {
-    font-size: 2rem;
-  }
-  
-  .header {
+  .footerSection {
     flex-direction: column;
-    align-items: flex-start;
-  }
-  
-  .actions {
-    width: 100%;
-    justify-content: flex-end;
+    align-items: stretch;
   }
 }
 
 @media (max-width: 480px) {
   .container {
-    padding: 24px 1rem;
+    padding: 0.5rem;
   }
   
   .title {

--- a/app/admin/editor/page.module.scss
+++ b/app/admin/editor/page.module.scss
@@ -58,23 +58,34 @@
   color: white;
   border: none;
   border-radius: 6px;
-  font-weight: 500;
+  font-weight: 600;
+  font-size: 1rem;
+  min-width: 120px;
+  height: auto;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition: all 0.2s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   
   &:hover {
     background-color: #5038af;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
   }
   
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+    box-shadow: 0 0 0 3px rgba(100, 74, 201, 0.2);
   }
   
   &:disabled {
     background-color: #e2e8f0;
     color: #94a3b8;
     cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
   }
 }
 
@@ -142,13 +153,24 @@
 
 .footerSection {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  margin-top: 1rem;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  width: 100%;
   
   @media (max-width: 768px) {
     flex-direction: column;
+    gap: 1rem;
+    
+    > *:first-child {
+      width: 100%;
+    }
+    
+    .saveButton {
+      align-self: flex-end;
+      width: auto;
+    }
   }
 }
 

--- a/app/admin/editor/page.tsx
+++ b/app/admin/editor/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import Link from 'next/link';
+import { useState, useEffect, useRef } from 'react';
 import styles from './page.module.scss';
 import MarkdownEditor from '@/app/components/admin/markdown/MarkdownEditor';
 import TitleInput from '@/app/components/admin/markdown/TitleInput';
@@ -14,28 +13,30 @@ export default function MarkdownEditorPage() {
   const [tags, setTags] = useState<string[]>([]);
   const [markdownContent, setMarkdownContent] = useState('');
   const [isDirty, setIsDirty] = useState(false);
+  const [titleError, setTitleError] = useState('');
+  const [isTitleValid, setIsTitleValid] = useState(true);
   
   // 마크다운 예시 콘텐츠
-  const exampleMarkdown = `# Welcome to Markdown Editor
+  const exampleMarkdown = `# 마크다운 에디터에 오신 것을 환영합니다
 
-This is a simple example of how the markdown editor works.
+이것은 마크다운 에디터 작동 방식의 간단한 예시입니다.
 
-## Features
+## 기능
 
-- **Bold text** and *italic text*
-- Lists (ordered and unordered)
-- [Links](https://example.com)
-- Code blocks:
+- **굵은 텍스트**와 *기울임 텍스트*
+- 목록 (순서 있는 목록과 없는 목록)
+- [링크](https://example.com)
+- 코드 블록:
 
 \`\`\`javascript
 function hello() {
-  console.log("Hello World");
+  console.log("안녕하세요");
 }
 \`\`\`
 
-> Blockquotes are also supported
+> 인용구도 지원됩니다
 
-Enjoy writing with markdown!
+마크다운으로 즐겁게 작성하세요!
 `;
 
   // 초기 마크다운 콘텐츠 설정
@@ -57,6 +58,12 @@ Enjoy writing with markdown!
     setTitle(newTitle);
   };
   
+  // 타이틀 유효성 검사 핸들러
+  const handleTitleValidation = (isValid: boolean, errorMessage: string) => {
+    setIsTitleValid(isValid);
+    setTitleError(errorMessage);
+  };
+  
   // 카테고리 변경 핸들러
   const handleCategoryChange = (newCategory: string) => {
     setCategory(newCategory);
@@ -74,6 +81,17 @@ Enjoy writing with markdown!
   
   // 저장 핸들러 (현재는 콘솔에 출력만)
   const handleSave = () => {
+    // 제목 유효성 검사
+    if (!isTitleValid) {
+      alert(titleError || '제목을 올바르게 입력해주세요.');
+      return;
+    }
+    
+    if (title.trim() === '') {
+      alert('제목을 입력해주세요.');
+      return;
+    }
+    
     console.log({
       title,
       category,
@@ -81,46 +99,23 @@ Enjoy writing with markdown!
       markdownContent
     });
     
-    alert('Post saved successfully! (This is a placeholder)');
+    alert('글이 저장되었습니다! (임시 알림)');
     setIsDirty(false);
   };
   
   return (
     <main className={styles.container}>
-      <div className={styles.header}>
-        <Link href="/admin" className={styles.backLink}>
-          ← Back to Dashboard
-        </Link>
-        
-        <h1 className={styles.title}>Markdown Editor</h1>
-        
-        <div className={styles.actions}>
-          <button 
-            className={styles.saveButton}
-            onClick={handleSave}
-            disabled={!isDirty}
-          >
-            Save Post
-          </button>
-        </div>
-      </div>
-      
       <div className={styles.editorForm}>
-        <div className={styles.metadataSection}>
+        <div className={styles.titleSection}>
           <TitleInput 
             initialTitle={title}
             onChange={handleTitleChange}
+            onValidate={handleTitleValidation}
           />
-          
-          <div className={styles.metadataColumns}>
+          <div className={styles.categoryWrapper}>
             <CategorySelector 
               initialCategory={category}
               onChange={handleCategoryChange}
-            />
-            
-            <TagsInput 
-              initialTags={tags}
-              onChange={handleTagsChange}
             />
           </div>
         </div>
@@ -129,6 +124,21 @@ Enjoy writing with markdown!
           initialContent={markdownContent}
           onChange={handleMarkdownChange}
         />
+        
+        <div className={styles.footerSection}>
+          <TagsInput 
+            initialTags={tags}
+            onChange={handleTagsChange}
+          />
+          
+          <button 
+            className={styles.saveButton}
+            onClick={handleSave}
+            disabled={!isDirty}
+          >
+            저장하기
+          </button>
+        </div>
       </div>
     </main>
   );

--- a/app/admin/editor/page.tsx
+++ b/app/admin/editor/page.tsx
@@ -17,26 +17,26 @@ export default function MarkdownEditorPage() {
   const [isTitleValid, setIsTitleValid] = useState(true);
   
   // 마크다운 예시 콘텐츠
-  const exampleMarkdown = `# 마크다운 에디터에 오신 것을 환영합니다
+  const exampleMarkdown = `# Welcome to Markdown Editor
 
-이것은 마크다운 에디터 작동 방식의 간단한 예시입니다.
+This is a simple example of how the markdown editor works.
 
-## 기능
+## Features
 
-- **굵은 텍스트**와 *기울임 텍스트*
-- 목록 (순서 있는 목록과 없는 목록)
-- [링크](https://example.com)
-- 코드 블록:
+- **Bold text** and *italic text*
+- Lists (ordered and unordered)
+- [Links](https://example.com)
+- Code blocks:
 
 \`\`\`javascript
 function hello() {
-  console.log("안녕하세요");
+  console.log("Hello World");
 }
 \`\`\`
 
-> 인용구도 지원됩니다
+> Blockquotes are also supported
 
-마크다운으로 즐겁게 작성하세요!
+Enjoy writing with markdown!
 `;
 
   // 초기 마크다운 콘텐츠 설정
@@ -83,12 +83,12 @@ function hello() {
   const handleSave = () => {
     // 제목 유효성 검사
     if (!isTitleValid) {
-      alert(titleError || '제목을 올바르게 입력해주세요.');
+      alert(titleError || 'Please enter a valid title.');
       return;
     }
     
     if (title.trim() === '') {
-      alert('제목을 입력해주세요.');
+      alert('Title cannot be empty.');
       return;
     }
     
@@ -99,7 +99,7 @@ function hello() {
       markdownContent
     });
     
-    alert('글이 저장되었습니다! (임시 알림)');
+    alert('Post saved successfully! (This is a placeholder)');
     setIsDirty(false);
   };
   
@@ -136,7 +136,7 @@ function hello() {
             onClick={handleSave}
             disabled={!isDirty}
           >
-            저장하기
+            Save Post
           </button>
         </div>
       </div>

--- a/app/admin/editor/page.tsx
+++ b/app/admin/editor/page.tsx
@@ -4,9 +4,16 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import styles from './page.module.scss';
 import MarkdownEditor from '@/app/components/admin/markdown/MarkdownEditor';
+import TitleInput from '@/app/components/admin/markdown/TitleInput';
+import CategorySelector from '@/app/components/admin/markdown/CategorySelector';
+import TagsInput from '@/app/components/admin/markdown/TagsInput';
 
 export default function MarkdownEditorPage() {
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('No Category');
+  const [tags, setTags] = useState<string[]>([]);
   const [markdownContent, setMarkdownContent] = useState('');
+  const [isDirty, setIsDirty] = useState(false);
   
   // 마크다운 예시 콘텐츠
   const exampleMarkdown = `# Welcome to Markdown Editor
@@ -36,20 +43,86 @@ Enjoy writing with markdown!
     setMarkdownContent(exampleMarkdown);
   }, []);
   
+  // 변경 감지
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsDirty(true);
+    }, 500);
+    
+    return () => clearTimeout(timer);
+  }, [title, category, tags, markdownContent]);
+  
+  // 타이틀 변경 핸들러
+  const handleTitleChange = (newTitle: string) => {
+    setTitle(newTitle);
+  };
+  
+  // 카테고리 변경 핸들러
+  const handleCategoryChange = (newCategory: string) => {
+    setCategory(newCategory);
+  };
+  
+  // 태그 변경 핸들러
+  const handleTagsChange = (newTags: string[]) => {
+    setTags(newTags);
+  };
+  
   // 마크다운 콘텐츠 변경 핸들러
   const handleMarkdownChange = (content: string) => {
     setMarkdownContent(content);
   };
   
+  // 저장 핸들러 (현재는 콘솔에 출력만)
+  const handleSave = () => {
+    console.log({
+      title,
+      category,
+      tags,
+      markdownContent
+    });
+    
+    alert('Post saved successfully! (This is a placeholder)');
+    setIsDirty(false);
+  };
+  
   return (
-    <main className="subPage">
-      <div className={styles.container}>
-        <div className={styles.header}>
-          <Link href="/admin" className={styles.backLink}>
-            ← Back to Dashboard
-          </Link>
+    <main className={styles.container}>
+      <div className={styles.header}>
+        <Link href="/admin" className={styles.backLink}>
+          ← Back to Dashboard
+        </Link>
+        
+        <h1 className={styles.title}>Markdown Editor</h1>
+        
+        <div className={styles.actions}>
+          <button 
+            className={styles.saveButton}
+            onClick={handleSave}
+            disabled={!isDirty}
+          >
+            Save Post
+          </button>
+        </div>
+      </div>
+      
+      <div className={styles.editorForm}>
+        <div className={styles.metadataSection}>
+          <TitleInput 
+            initialTitle={title}
+            onChange={handleTitleChange}
+          />
           
-          <h1 className={styles.title}>Markdown Editor</h1>
+          <div className={styles.metadataColumns}>
+            <CategorySelector 
+              initialCategory={category}
+              onChange={handleCategoryChange}
+            />
+            
+            <TagsInput 
+              initialTags={tags}
+              onChange={handleTagsChange}
+            />
+          </div>
         </div>
         
         <MarkdownEditor 

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from "next";
 import "../(global)/globals.css";
+import AdminLayout from "../components/admin/layout/Layout";
 
 export const metadata: Metadata = {
   title: "Admin - My Blog",
   description: "Admin dashboard for the blog",
 };
 
-export default function AdminLayout({
+export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
@@ -14,14 +15,9 @@ export default function AdminLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body suppressHydrationWarning className="admin-layout">
-        <div className="admin-container">
-          <header className="admin-header">
-            <h1>Admin Dashboard</h1>
-          </header>
-          <main className="admin-content">
-            {children}
-          </main>
-        </div>
+        <AdminLayout>
+          {children}
+        </AdminLayout>
       </body>
     </html>
   );

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -6,20 +6,20 @@ import styles from './page.module.scss';
 
 export default function AdminDashboardPage() {
   useEffect(() => {
-    // Admin 페이지 초기화 로직을 여기에 작성합니다
+    // Admin page initialization logic goes here
   }, []);
 
   return (
     <div className={styles.container}>
-      <h2 className={styles.title}>관리자 대시보드</h2>
+      <h2 className={styles.title}>Admin Dashboard</h2>
       
       <div className={styles.actionCard}>
-        <h3>콘텐츠 관리</h3>
+        <h3>Content Management</h3>
         <div className={styles.actionLinks}>
           <Link href="/admin/editor" className={styles.actionLink}>
-            마크다운 에디터
+            Markdown Editor
           </Link>
-          {/* 추가 링크들 */}
+          {/* Additional links */}
         </div>
       </div>
     </div>

--- a/app/components/admin/layout/Header.module.scss
+++ b/app/components/admin/layout/Header.module.scss
@@ -1,0 +1,251 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 72px;
+  padding: 0 1.5rem;
+  background-color: white;
+  border-bottom: 1px solid #e2e8f0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  
+  @media (min-width: 992px) {
+    padding-left: calc(280px + 1.5rem);
+    transition: padding 0.3s ease;
+  }
+}
+
+.headerCollapsed {
+  @media (min-width: 992px) {
+    padding-left: calc(80px + 1.5rem);
+  }
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  
+  @media (min-width: 992px) {
+    display: none;
+  }
+}
+
+.menuToggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background-color: transparent;
+  color: #64748b;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-right: 1rem;
+  
+  &:hover {
+    background-color: #f1f5f9;
+    color: #334155;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  }
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.searchWrapper {
+  display: flex;
+  align-items: center;
+  position: relative;
+  width: 300px;
+  
+  @media (max-width: 768px) {
+    display: none;
+  }
+}
+
+.searchInput {
+  width: 100%;
+  height: 40px;
+  padding: 0 1rem 0 2.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 20px;
+  background-color: #f8fafc;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+  
+  &:focus {
+    outline: none;
+    border-color: #644AC9;
+    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+  }
+  
+  &::placeholder {
+    color: #94a3b8;
+  }
+}
+
+.searchButton {
+  position: absolute;
+  left: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  color: #94a3b8;
+  cursor: pointer;
+  
+  &:focus {
+    outline: none;
+  }
+}
+
+.notifications {
+  position: relative;
+}
+
+.iconButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background-color: transparent;
+  color: #64748b;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  
+  &:hover {
+    background-color: #f1f5f9;
+    color: #334155;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  }
+}
+
+.profile {
+  position: relative;
+}
+
+.profileButton {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 20px;
+  border: none;
+  background-color: transparent;
+  color: #64748b;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  
+  &:hover {
+    background-color: #f1f5f9;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  }
+}
+
+.avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: #644AC9;
+  color: white;
+  margin-right: 0.75rem;
+  overflow: hidden;
+}
+
+.profileName {
+  font-size: 0.95rem;
+  font-weight: 500;
+  margin-right: 0.5rem;
+  
+  @media (max-width: 480px) {
+    display: none;
+  }
+}
+
+.profileMenu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  width: 220px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  z-index: 100;
+  border: 1px solid #e2e8f0;
+  overflow: hidden;
+  
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  
+  li {
+    &:not(:last-child) {
+      border-bottom: 1px solid #f1f5f9;
+    }
+  }
+}
+
+.profileMenuItem {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  background-color: transparent;
+  color: #64748b;
+  text-decoration: none;
+  font-size: 0.95rem;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  
+  svg {
+    margin-right: 0.75rem;
+    color: #64748b;
+  }
+  
+  &:hover {
+    background-color: #f8fafc;
+    color: #334155;
+    
+    svg {
+      color: #644AC9;
+    }
+  }
+}
+
+.divider {
+  height: 1px;
+  background-color: #e2e8f0;
+  margin: 0.5rem 0;
+} 

--- a/app/components/admin/layout/Header.module.scss
+++ b/app/components/admin/layout/Header.module.scss
@@ -1,7 +1,7 @@
 .header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   height: 72px;
   padding: 0 1.5rem;
   background-color: white;
@@ -14,47 +14,6 @@
   
   @media (min-width: 992px) {
     padding-left: calc(280px + 1.5rem);
-    transition: padding 0.3s ease;
-  }
-}
-
-.headerCollapsed {
-  @media (min-width: 992px) {
-    padding-left: calc(80px + 1.5rem);
-  }
-}
-
-.headerLeft {
-  display: flex;
-  align-items: center;
-  
-  @media (min-width: 992px) {
-    display: none;
-  }
-}
-
-.menuToggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: none;
-  background-color: transparent;
-  color: #64748b;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  margin-right: 1rem;
-  
-  &:hover {
-    background-color: #f1f5f9;
-    color: #334155;
-  }
-  
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
   }
 }
 

--- a/app/components/admin/layout/Header.module.scss
+++ b/app/components/admin/layout/Header.module.scss
@@ -1,26 +1,53 @@
 .header {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  justify-content: flex-end;
-  height: 72px;
-  padding: 0 1.5rem;
-  background-color: white;
+  background-color: #ffffff;
   border-bottom: 1px solid #e2e8f0;
+  padding: 0 1.5rem;
+  height: 72px;
   position: fixed;
   top: 0;
-  left: 0;
   right: 0;
-  z-index: 50;
+  left: 280px;
+  z-index: 99;
   
-  @media (min-width: 992px) {
-    padding-left: calc(280px + 1.5rem);
+  @media (max-width: 992px) {
+    left: 0;
+  }
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+}
+
+.menuToggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: #64748b;
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  cursor: pointer;
+  
+  &:hover {
+    background-color: #f1f5f9;
+    color: #334155;
+  }
+  
+  @media (min-width: 993px) {
+    display: none;
   }
 }
 
 .headerRight {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  margin-left: auto;
 }
 
 .searchWrapper {

--- a/app/components/admin/layout/Header.tsx
+++ b/app/components/admin/layout/Header.tsx
@@ -4,29 +4,11 @@ import { useState } from 'react';
 import Link from 'next/link';
 import styles from './Header.module.scss';
 
-interface HeaderProps {
-  toggleSidebar: () => void;
-}
-
-export default function Header({ toggleSidebar }: HeaderProps) {
+export default function Header() {
   const [showProfileMenu, setShowProfileMenu] = useState(false);
   
   return (
     <header className={styles.header}>
-      <div className={styles.headerLeft}>
-        <button 
-          className={styles.menuToggle}
-          onClick={toggleSidebar}
-          aria-label="Toggle sidebar menu"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="3" y1="12" x2="21" y2="12" />
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="3" y1="18" x2="21" y2="18" />
-          </svg>
-        </button>
-      </div>
-      
       <div className={styles.headerRight}>
         <div className={styles.searchWrapper}>
           <input

--- a/app/components/admin/layout/Header.tsx
+++ b/app/components/admin/layout/Header.tsx
@@ -29,20 +29,6 @@ export default function Header({ toggleSidebar, isSidebarOpen }: HeaderProps) {
       </div>
       
       <div className={styles.headerRight}>
-        <div className={styles.searchWrapper}>
-          <input
-            type="text"
-            className={styles.searchInput}
-            placeholder="Search..."
-            aria-label="Search"
-          />
-          <button className={styles.searchButton} aria-label="Search">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="11" cy="11" r="8" />
-              <line x1="21" y1="21" x2="16.65" y2="16.65" />
-            </svg>
-          </button>
-        </div>
         
         <div className={styles.notifications}>
           <button className={styles.iconButton} aria-label="Notifications">

--- a/app/components/admin/layout/Header.tsx
+++ b/app/components/admin/layout/Header.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import styles from './Header.module.scss';
+
+interface HeaderProps {
+  toggleSidebar: () => void;
+}
+
+export default function Header({ toggleSidebar }: HeaderProps) {
+  const [showProfileMenu, setShowProfileMenu] = useState(false);
+  
+  return (
+    <header className={styles.header}>
+      <div className={styles.headerLeft}>
+        <button 
+          className={styles.menuToggle}
+          onClick={toggleSidebar}
+          aria-label="Toggle sidebar menu"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        </button>
+      </div>
+      
+      <div className={styles.headerRight}>
+        <div className={styles.searchWrapper}>
+          <input
+            type="text"
+            className={styles.searchInput}
+            placeholder="검색..."
+            aria-label="Search"
+          />
+          <button className={styles.searchButton} aria-label="Search">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+          </button>
+        </div>
+        
+        <div className={styles.notifications}>
+          <button className={styles.iconButton} aria-label="Notifications">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+              <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+            </svg>
+          </button>
+        </div>
+        
+        <div className={styles.profile}>
+          <button 
+            className={styles.profileButton} 
+            onClick={() => setShowProfileMenu(!showProfileMenu)}
+            aria-label="User profile"
+            aria-expanded={showProfileMenu}
+          >
+            <div className={styles.avatar}>
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+            </div>
+            <span className={styles.profileName}>관리자</span>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m6 9 6 6 6-6" />
+            </svg>
+          </button>
+          
+          {showProfileMenu && (
+            <div className={styles.profileMenu}>
+              <ul>
+                <li>
+                  <Link href="/admin/profile" className={styles.profileMenuItem}>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+                      <circle cx="12" cy="7" r="4" />
+                    </svg>
+                    <span>내 프로필</span>
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/admin/settings" className={styles.profileMenuItem}>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+                      <circle cx="12" cy="12" r="3" />
+                    </svg>
+                    <span>설정</span>
+                  </Link>
+                </li>
+                <li className={styles.divider}></li>
+                <li>
+                  <button className={styles.profileMenuItem}>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                      <polyline points="16 17 21 12 16 7" />
+                      <line x1="21" y1="12" x2="9" y2="12" />
+                    </svg>
+                    <span>로그아웃</span>
+                  </button>
+                </li>
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+} 

--- a/app/components/admin/layout/Header.tsx
+++ b/app/components/admin/layout/Header.tsx
@@ -4,17 +4,36 @@ import { useState } from 'react';
 import Link from 'next/link';
 import styles from './Header.module.scss';
 
-export default function Header() {
+interface HeaderProps {
+  toggleSidebar: () => void;
+  isSidebarOpen: boolean;
+}
+
+export default function Header({ toggleSidebar, isSidebarOpen }: HeaderProps) {
   const [showProfileMenu, setShowProfileMenu] = useState(false);
   
   return (
     <header className={styles.header}>
+      <div className={styles.headerLeft}>
+        <button 
+          className={styles.menuToggle} 
+          onClick={toggleSidebar}
+          aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        </button>
+      </div>
+      
       <div className={styles.headerRight}>
         <div className={styles.searchWrapper}>
           <input
             type="text"
             className={styles.searchInput}
-            placeholder="검색..."
+            placeholder="Search..."
             aria-label="Search"
           />
           <button className={styles.searchButton} aria-label="Search">
@@ -47,7 +66,7 @@ export default function Header() {
                 <circle cx="12" cy="7" r="4" />
               </svg>
             </div>
-            <span className={styles.profileName}>관리자</span>
+            <span className={styles.profileName}>Admin</span>
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="m6 9 6 6 6-6" />
             </svg>
@@ -62,7 +81,7 @@ export default function Header() {
                       <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
                       <circle cx="12" cy="7" r="4" />
                     </svg>
-                    <span>내 프로필</span>
+                    <span>My Profile</span>
                   </Link>
                 </li>
                 <li>
@@ -71,7 +90,7 @@ export default function Header() {
                       <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
                       <circle cx="12" cy="12" r="3" />
                     </svg>
-                    <span>설정</span>
+                    <span>Settings</span>
                   </Link>
                 </li>
                 <li className={styles.divider}></li>
@@ -82,7 +101,7 @@ export default function Header() {
                       <polyline points="16 17 21 12 16 7" />
                       <line x1="21" y1="12" x2="9" y2="12" />
                     </svg>
-                    <span>로그아웃</span>
+                    <span>Logout</span>
                   </button>
                 </li>
               </ul>

--- a/app/components/admin/layout/Layout.module.scss
+++ b/app/components/admin/layout/Layout.module.scss
@@ -1,0 +1,30 @@
+.adminLayout {
+  display: flex;
+  width: 100%;
+  min-height: 100vh;
+  background-color: #f8fafc;
+}
+
+.content {
+  flex: 1;
+  padding: 2rem;
+  margin-top: 72px;
+  margin-left: 280px;
+  transition: margin-left 0.3s ease;
+  width: calc(100% - 280px);
+  
+  @media (max-width: 992px) {
+    margin-left: 0;
+    width: 100%;
+  }
+}
+
+.contentExpanded {
+  margin-left: 80px;
+  width: calc(100% - 80px);
+  
+  @media (max-width: 992px) {
+    margin-left: 0;
+    width: 100%;
+  }
+} 

--- a/app/components/admin/layout/Layout.module.scss
+++ b/app/components/admin/layout/Layout.module.scss
@@ -26,4 +26,24 @@
     margin-left: 0;
     width: 100%;
   }
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 90;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 } 

--- a/app/components/admin/layout/Layout.module.scss
+++ b/app/components/admin/layout/Layout.module.scss
@@ -7,10 +7,9 @@
 
 .content {
   flex: 1;
-  padding: 2rem;
+  padding: 1.5rem;
   margin-top: 72px;
   margin-left: 280px;
-  transition: margin-left 0.3s ease;
   width: calc(100% - 280px);
   
   @media (max-width: 992px) {

--- a/app/components/admin/layout/Layout.tsx
+++ b/app/components/admin/layout/Layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import Sidebar from './Sidebar';
 import Header from './Header';
 import styles from './Layout.module.scss';
@@ -9,13 +10,50 @@ interface AdminLayoutProps {
 }
 
 export default function AdminLayout({ children }: AdminLayoutProps) {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 992);
+      if (window.innerWidth < 992) {
+        setIsSidebarOpen(false);
+      } else {
+        setIsSidebarOpen(true);
+      }
+    };
+
+    // Initial check
+    checkMobile();
+
+    // Add event listener
+    window.addEventListener('resize', checkMobile);
+
+    // Clean up
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  const toggleSidebar = () => {
+    setIsSidebarOpen(!isSidebarOpen);
+  };
+
+  const closeSidebar = () => {
+    if (isMobile) {
+      setIsSidebarOpen(false);
+    }
+  };
+
   return (
     <div className={styles.adminLayout}>
-      <Sidebar />
-      <Header />
-      <main className={styles.content}>
+      <Sidebar isOpen={isSidebarOpen} />
+      <Header toggleSidebar={toggleSidebar} isSidebarOpen={isSidebarOpen} />
+      <main className={`${styles.content} ${isSidebarOpen ? '' : styles.contentExpanded}`}>
         {children}
       </main>
+      
+      {isMobile && isSidebarOpen && (
+        <div className={styles.overlay} onClick={closeSidebar}></div>
+      )}
     </div>
   );
 } 

--- a/app/components/admin/layout/Layout.tsx
+++ b/app/components/admin/layout/Layout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import Sidebar from './Sidebar';
 import Header from './Header';
 import styles from './Layout.module.scss';
@@ -10,20 +9,11 @@ interface AdminLayoutProps {
 }
 
 export default function AdminLayout({ children }: AdminLayoutProps) {
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  
-  // 사이드바 토글
-  const toggleSidebar = () => {
-    setSidebarCollapsed(!sidebarCollapsed);
-  };
-  
   return (
     <div className={styles.adminLayout}>
       <Sidebar />
-      <Header 
-        toggleSidebar={toggleSidebar}
-      />
-      <main className={`${styles.content} ${sidebarCollapsed ? styles.contentExpanded : ''}`}>
+      <Header />
+      <main className={styles.content}>
         {children}
       </main>
     </div>

--- a/app/components/admin/layout/Layout.tsx
+++ b/app/components/admin/layout/Layout.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import Sidebar from './Sidebar';
+import Header from './Header';
+import styles from './Layout.module.scss';
+
+interface AdminLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function AdminLayout({ children }: AdminLayoutProps) {
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  
+  // 사이드바 토글
+  const toggleSidebar = () => {
+    setSidebarCollapsed(!sidebarCollapsed);
+  };
+  
+  return (
+    <div className={styles.adminLayout}>
+      <Sidebar />
+      <Header 
+        toggleSidebar={toggleSidebar}
+      />
+      <main className={`${styles.content} ${sidebarCollapsed ? styles.contentExpanded : ''}`}>
+        {children}
+      </main>
+    </div>
+  );
+} 

--- a/app/components/admin/layout/Sidebar.module.scss
+++ b/app/components/admin/layout/Sidebar.module.scss
@@ -5,24 +5,18 @@
   height: 100%;
   background-color: #f8fafc;
   border-right: 1px solid #e2e8f0;
-  transition: all 0.3s ease;
   position: fixed;
   top: 0;
   left: 0;
   bottom: 0;
   z-index: 100;
-  
-  &.collapsed {
-    width: 80px;
-  }
 }
 
 .sidebarHeader {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   padding: 1.5rem 1.5rem;
-  border-bottom: 1px solid #e2e8f0;
 }
 
 .sidebarTitle {
@@ -33,30 +27,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.collapseButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 6px;
-  border: none;
-  background-color: white;
-  color: #64748b;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  
-  &:hover {
-    background-color: #f1f5f9;
-    color: #334155;
-  }
-  
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
-  }
 }
 
 .navigation {
@@ -129,7 +99,6 @@
 
 .sidebarFooter {
   padding: 1.5rem;
-  border-top: 1px solid #e2e8f0;
 }
 
 .viewSiteLink {
@@ -155,12 +124,8 @@
 // 반응형 스타일
 @media (max-width: 992px) {
   .sidebar {
-    width: 240px;
-    
-    &.collapsed {
-      width: 0;
-      transform: translateX(-100%);
-    }
+    width: 280px;
+    transform: translateX(-100%);
   }
 }
 
@@ -168,10 +133,6 @@
   .sidebar {
     width: 100%;
     max-width: 280px;
-    
-    &.collapsed {
-      width: 0;
-      transform: translateX(-100%);
-    }
+    transform: translateX(-100%);
   }
 } 

--- a/app/components/admin/layout/Sidebar.module.scss
+++ b/app/components/admin/layout/Sidebar.module.scss
@@ -10,6 +10,15 @@
   left: 0;
   bottom: 0;
   z-index: 100;
+  transition: transform 0.3s ease;
+  
+  @media (max-width: 992px) {
+    transform: translateX(-100%);
+    
+    &.open {
+      transform: translateX(0);
+    }
+  }
 }
 
 .sidebarHeader {
@@ -122,13 +131,6 @@
 }
 
 // 반응형 스타일
-@media (max-width: 992px) {
-  .sidebar {
-    width: 280px;
-    transform: translateX(-100%);
-  }
-}
-
 @media (max-width: 768px) {
   .sidebar {
     width: 100%;

--- a/app/components/admin/layout/Sidebar.module.scss
+++ b/app/components/admin/layout/Sidebar.module.scss
@@ -1,0 +1,177 @@
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  width: 280px;
+  height: 100%;
+  background-color: #f8fafc;
+  border-right: 1px solid #e2e8f0;
+  transition: all 0.3s ease;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 100;
+  
+  &.collapsed {
+    width: 80px;
+  }
+}
+
+.sidebarHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.sidebarTitle {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #644AC9;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collapseButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  border: none;
+  background-color: white;
+  color: #64748b;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  
+  &:hover {
+    background-color: #f1f5f9;
+    color: #334155;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  }
+}
+
+.navigation {
+  flex: 1;
+  padding: 1.5rem 0;
+  overflow-y: auto;
+  
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background-color: #e2e8f0;
+    border-radius: 2px;
+  }
+}
+
+.menuList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.menuItem {
+  margin-bottom: 0.5rem;
+}
+
+.menuLink {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  color: #64748b;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  border-left: 3px solid transparent;
+  
+  &:hover {
+    background-color: #f1f5f9;
+    color: #334155;
+  }
+  
+  &.active {
+    background-color: #eff6ff;
+    color: #644AC9;
+    border-left: 3px solid #644AC9;
+  }
+}
+
+.menuIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 0.75rem;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.menuText {
+  font-size: 1rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebarFooter {
+  padding: 1.5rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.viewSiteLink {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background-color: #644AC9;
+  border-radius: 6px;
+  color: white;
+  text-decoration: none;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  
+  svg {
+    margin-right: 0.75rem;
+  }
+  
+  &:hover {
+    background-color: #5038af;
+  }
+}
+
+// 반응형 스타일
+@media (max-width: 992px) {
+  .sidebar {
+    width: 240px;
+    
+    &.collapsed {
+      width: 0;
+      transform: translateX(-100%);
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    width: 100%;
+    max-width: 280px;
+    
+    &.collapsed {
+      width: 0;
+      transform: translateX(-100%);
+    }
+  }
+} 

--- a/app/components/admin/layout/Sidebar.tsx
+++ b/app/components/admin/layout/Sidebar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import styles from './Sidebar.module.scss';
@@ -11,13 +10,17 @@ interface MenuItem {
   icon: React.ReactNode;
 }
 
-export default function Sidebar() {
+interface SidebarProps {
+  isOpen: boolean;
+}
+
+export default function Sidebar({ isOpen }: SidebarProps) {
   const pathname = usePathname();
   
-  // 메뉴 아이템 정의
+  // Menu items definition
   const menuItems: MenuItem[] = [
     {
-      name: '대시보드',
+      name: 'Dashboard',
       path: '/admin',
       icon: (
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -29,7 +32,7 @@ export default function Sidebar() {
       )
     },
     {
-      name: '글 작성',
+      name: 'Write Post',
       path: '/admin/editor',
       icon: (
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -39,7 +42,7 @@ export default function Sidebar() {
       )
     },
     {
-      name: '글 관리',
+      name: 'Posts',
       path: '/admin/posts',
       icon: (
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -52,7 +55,7 @@ export default function Sidebar() {
       )
     },
     {
-      name: '카테고리',
+      name: 'Categories',
       path: '/admin/categories',
       icon: (
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -61,7 +64,7 @@ export default function Sidebar() {
       )
     },
     {
-      name: '설정',
+      name: 'Settings',
       path: '/admin/settings',
       icon: (
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -73,7 +76,7 @@ export default function Sidebar() {
   ];
   
   return (
-    <aside className={styles.sidebar}>
+    <aside className={`${styles.sidebar} ${isOpen ? styles.open : ''}`}>
       <div className={styles.sidebarHeader}>
         <h2 className={styles.sidebarTitle}>DokaDev</h2>
       </div>
@@ -105,7 +108,7 @@ export default function Sidebar() {
             <path d="M15 3h6v6" />
             <path d="m10 14 11-11" />
           </svg>
-          <span>사이트 보기</span>
+          <span>View Site</span>
         </Link>
       </div>
     </aside>

--- a/app/components/admin/layout/Sidebar.tsx
+++ b/app/components/admin/layout/Sidebar.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import styles from './Sidebar.module.scss';
+
+interface MenuItem {
+  name: string;
+  path: string;
+  icon: React.ReactNode;
+}
+
+export default function Sidebar() {
+  const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
+  
+  // 메뉴 아이템 정의
+  const menuItems: MenuItem[] = [
+    {
+      name: '대시보드',
+      path: '/admin',
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect width="7" height="9" x="3" y="3" rx="1" />
+          <rect width="7" height="5" x="14" y="3" rx="1" />
+          <rect width="7" height="9" x="14" y="12" rx="1" />
+          <rect width="7" height="5" x="3" y="16" rx="1" />
+        </svg>
+      )
+    },
+    {
+      name: '글 작성',
+      path: '/admin/editor',
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 20h9" />
+          <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+        </svg>
+      )
+    },
+    {
+      name: '글 관리',
+      path: '/admin/posts',
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <path d="M14 2v6h6" />
+          <path d="M16 13H8" />
+          <path d="M16 17H8" />
+          <path d="M10 9H8" />
+        </svg>
+      )
+    },
+    {
+      name: '카테고리',
+      path: '/admin/categories',
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" />
+        </svg>
+      )
+    },
+    {
+      name: '설정',
+      path: '/admin/settings',
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+      )
+    }
+  ];
+  
+  // 사이드바 토글 핸들러
+  const toggleSidebar = () => {
+    setCollapsed(!collapsed);
+  };
+  
+  return (
+    <aside className={`${styles.sidebar} ${collapsed ? styles.collapsed : ''}`}>
+      <div className={styles.sidebarHeader}>
+        <h2 className={styles.sidebarTitle}>DokaDev</h2>
+        <button 
+          className={styles.collapseButton} 
+          onClick={toggleSidebar}
+          aria-label="Toggle sidebar"
+        >
+          {collapsed ? (
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m9 18 6-6-6-6" />
+            </svg>
+          ) : (
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+          )}
+        </button>
+      </div>
+      
+      <nav className={styles.navigation}>
+        <ul className={styles.menuList}>
+          {menuItems.map((item, index) => {
+            const isActive = pathname === item.path;
+            
+            return (
+              <li key={index} className={styles.menuItem}>
+                <Link 
+                  href={item.path} 
+                  className={`${styles.menuLink} ${isActive ? styles.active : ''}`}
+                >
+                  <span className={styles.menuIcon}>{item.icon}</span>
+                  {!collapsed && <span className={styles.menuText}>{item.name}</span>}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+      
+      <div className={styles.sidebarFooter}>
+        <Link href="/" className={styles.viewSiteLink}>
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+            <path d="M15 3h6v6" />
+            <path d="m10 14 11-11" />
+          </svg>
+          {!collapsed && <span>사이트 보기</span>}
+        </Link>
+      </div>
+    </aside>
+  );
+} 

--- a/app/components/admin/layout/Sidebar.tsx
+++ b/app/components/admin/layout/Sidebar.tsx
@@ -13,7 +13,6 @@ interface MenuItem {
 
 export default function Sidebar() {
   const pathname = usePathname();
-  const [collapsed, setCollapsed] = useState(false);
   
   // 메뉴 아이템 정의
   const menuItems: MenuItem[] = [
@@ -73,30 +72,10 @@ export default function Sidebar() {
     }
   ];
   
-  // 사이드바 토글 핸들러
-  const toggleSidebar = () => {
-    setCollapsed(!collapsed);
-  };
-  
   return (
-    <aside className={`${styles.sidebar} ${collapsed ? styles.collapsed : ''}`}>
+    <aside className={styles.sidebar}>
       <div className={styles.sidebarHeader}>
         <h2 className={styles.sidebarTitle}>DokaDev</h2>
-        <button 
-          className={styles.collapseButton} 
-          onClick={toggleSidebar}
-          aria-label="Toggle sidebar"
-        >
-          {collapsed ? (
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="m9 18 6-6-6-6" />
-            </svg>
-          ) : (
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="m15 18-6-6 6-6" />
-            </svg>
-          )}
-        </button>
       </div>
       
       <nav className={styles.navigation}>
@@ -111,7 +90,7 @@ export default function Sidebar() {
                   className={`${styles.menuLink} ${isActive ? styles.active : ''}`}
                 >
                   <span className={styles.menuIcon}>{item.icon}</span>
-                  {!collapsed && <span className={styles.menuText}>{item.name}</span>}
+                  <span className={styles.menuText}>{item.name}</span>
                 </Link>
               </li>
             );
@@ -126,7 +105,7 @@ export default function Sidebar() {
             <path d="M15 3h6v6" />
             <path d="m10 14 11-11" />
           </svg>
-          {!collapsed && <span>사이트 보기</span>}
+          <span>사이트 보기</span>
         </Link>
       </div>
     </aside>

--- a/app/components/admin/markdown/CategorySelector.module.scss
+++ b/app/components/admin/markdown/CategorySelector.module.scss
@@ -1,0 +1,294 @@
+.categorySelector {
+  position: relative;
+  margin-bottom: 1.5rem;
+  width: 100%;
+}
+
+.selectedCategory {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background-color: white;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  
+  &:hover {
+    border-color: #cbd5e1;
+  }
+  
+  span {
+    font-size: 1rem;
+    font-weight: 500;
+    color: #334155;
+    
+    &.noCategory {
+      color: #94a3b8;
+      font-style: italic;
+    }
+  }
+  
+  svg {
+    color: #64748b;
+  }
+}
+
+// 카테고리 모달
+.categoryModal {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  width: 100%;
+  max-height: 400px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  z-index: 100;
+  border: 1px solid #e2e8f0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  
+  h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #334155;
+  }
+  
+  .closeButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: none;
+    background-color: transparent;
+    color: #64748b;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    
+    &:hover {
+      background-color: #f1f5f9;
+      color: #334155;
+    }
+    
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+    }
+  }
+}
+
+.searchContainer {
+  position: relative;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 0.75rem 1rem 0.75rem 2.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  
+  &:focus {
+    outline: none;
+    border-color: #644AC9;
+    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+  }
+  
+  &::placeholder {
+    color: #94a3b8;
+  }
+}
+
+.searchIcon {
+  position: absolute;
+  left: 2.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #94a3b8;
+  pointer-events: none;
+}
+
+.clearButton {
+  position: absolute;
+  right: 2.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: none;
+  background-color: #f1f5f9;
+  color: #64748b;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  
+  &:hover {
+    background-color: #e2e8f0;
+    color: #334155;
+  }
+  
+  &:focus {
+    outline: none;
+  }
+}
+
+.categoriesList {
+  padding: 0.5rem;
+  overflow-y: auto;
+  flex: 1;
+  max-height: 250px;
+  
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: #f8fafc;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background-color: #e2e8f0;
+    border-radius: 3px;
+  }
+}
+
+.categoryItem {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  font-size: 0.95rem;
+  margin-bottom: 0.25rem;
+  
+  &:hover {
+    background-color: #f1f5f9;
+  }
+  
+  &.active {
+    background-color: #eff6ff;
+    color: #644AC9;
+    font-weight: 500;
+  }
+}
+
+.noResults {
+  padding: 1.5rem;
+  text-align: center;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.modalFooter {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.validateButton {
+  padding: 0.75rem 1.5rem;
+  background-color: #644AC9;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  
+  &:hover {
+    background-color: #5038af;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+  }
+}
+
+// 에러 모달
+.errorModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.errorModalContent {
+  width: 90%;
+  max-width: 400px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.errorModalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  background-color: #fee2e2;
+  color: #b91c1c;
+  
+  h4 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+  
+  .closeButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: none;
+    background-color: transparent;
+    color: #b91c1c;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    
+    &:hover {
+      background-color: rgba(185, 28, 28, 0.1);
+    }
+    
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.2);
+    }
+  }
+}
+
+.errorMessage {
+  padding: 1.5rem;
+  color: #4b5563;
+  font-size: 1rem;
+  line-height: 1.5;
+} 

--- a/app/components/admin/markdown/CategorySelector.module.scss
+++ b/app/components/admin/markdown/CategorySelector.module.scss
@@ -1,157 +1,161 @@
 .categorySelector {
   position: relative;
-  width: 100%;
+  display: inline-block;
 }
 
 .categoryButton {
+  padding: 0.75rem 1.25rem;
+  background-color: #644AC9;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
-  padding: 0.75rem 1rem;
-  background-color: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  font-size: 0.95rem;
-  color: #334155;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  
+  min-width: 180px;
+
   &:hover {
-    border-color: #644AC9;
+    background-color: #5038af;
   }
-  
+
   &:focus {
     outline: none;
-    border-color: #644AC9;
     box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+  }
+
+  .noCategory {
+    color: #e0e0e0;
+  }
+
+  svg {
+    margin-left: 8px;
+    transition: transform 0.2s ease-in-out;
   }
 }
 
-.noCategory {
-  color: #94a3b8;
+.categoryButton.modalOpen svg {
+  transform: rotate(180deg);
 }
 
 .categoryModal {
-  position: absolute;
-  top: calc(100% + 4px);
+  position: fixed;
+  top: 0;
   left: 0;
-  width: 100%;
-  background-color: white;
-  border-radius: 6px;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  z-index: 50;
-  border: 1px solid #e2e8f0;
-  overflow: hidden;
-  max-height: 350px;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+
+  .modalContent {
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+    width: 100%;
+    max-width: 500px;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
 }
 
 .modalHeader {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid #e2e8f0;
-  
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+
   h3 {
     margin: 0;
-    font-size: 1rem;
+    font-size: 1.25rem;
     font-weight: 600;
-    color: #334155;
+    color: #1f2937;
   }
 }
 
 .closeButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 4px;
+  background: none;
   border: none;
-  background-color: transparent;
-  color: #64748b;
   cursor: pointer;
-  transition: all 0.2s ease;
-  
+  padding: 0.5rem;
+  color: #6b7280;
+
   &:hover {
-    background-color: #f1f5f9;
-    color: #334155;
+    color: #1f2937;
   }
-  
-  &:focus {
-    outline: none;
+
+  svg {
+    display: block;
   }
 }
 
 .searchContainer {
+  padding: 1rem 1.5rem;
   position: relative;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid #e2e8f0;
-}
+  border-bottom: 1px solid #e5e7eb;
 
-.searchInput {
-  width: 100%;
-  padding: 0.5rem 1rem 0.5rem 2rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 4px;
-  font-size: 0.9rem;
-  
-  &:focus {
-    outline: none;
-    border-color: #644AC9;
-    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+  .searchInput {
+    width: 100%;
+    padding: 0.75rem 2.5rem 0.75rem 1rem;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 1rem;
+    transition: border-color 0.2s, box-shadow 0.2s;
+
+    &:focus {
+      outline: none;
+      border-color: #0070f3;
+      box-shadow: 0 0 0 2px rgba(0, 112, 243, 0.2);
+    }
   }
-}
 
-.searchIcon {
-  position: absolute;
-  left: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #94a3b8;
+  .searchIcon {
+    position: absolute;
+    top: 50%;
+    right: 1.5rem + 0.5rem;
+    transform: translateY(-50%);
+    color: #9ca3af;
+    pointer-events: none;
+  }
 }
 
 .categoriesList {
+  padding: 0.5rem 0;
   overflow-y: auto;
-  max-height: 220px;
-  
-  &::-webkit-scrollbar {
-    width: 6px;
-  }
-  
-  &::-webkit-scrollbar-track {
-    background: #f8fafc;
-  }
-  
-  &::-webkit-scrollbar-thumb {
-    background-color: #e2e8f0;
-    border-radius: 3px;
-  }
-}
+  flex-grow: 1;
 
-.categoryItem {
-  padding: 0.5rem 1rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  
-  &:hover {
-    background-color: #f1f5f9;
-  }
-  
-  &.active {
-    background-color: #eff6ff;
-    color: #644AC9;
-    font-weight: 500;
+  .categoryItem {
+    padding: 0.75rem 1.5rem;
+    cursor: pointer;
+    font-size: 1rem;
+    color: #374151;
+    transition: background-color 0.15s, color 0.15s;
+
+    &:hover {
+      background-color: #f3f4f6;
+    }
+
+    &.active {
+      background-color: #e0f2fe;
+      color: #0c4a6e;
+      font-weight: 500;
+    }
   }
 }
 
 .noResults {
-  padding: 1rem;
+  padding: 1rem 1.5rem;
   text-align: center;
-  color: #94a3b8;
+  color: #6b7280;
   font-style: italic;
 }
 

--- a/app/components/admin/markdown/CategorySelector.module.scss
+++ b/app/components/admin/markdown/CategorySelector.module.scss
@@ -1,54 +1,49 @@
 .categorySelector {
   position: relative;
-  margin-bottom: 1.5rem;
   width: 100%;
 }
 
-.selectedCategory {
+.categoryButton {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
   padding: 0.75rem 1rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
   background-color: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  color: #334155;
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: all 0.2s ease;
   
   &:hover {
-    border-color: #cbd5e1;
+    border-color: #644AC9;
   }
   
-  span {
-    font-size: 1rem;
-    font-weight: 500;
-    color: #334155;
-    
-    &.noCategory {
-      color: #94a3b8;
-      font-style: italic;
-    }
-  }
-  
-  svg {
-    color: #64748b;
+  &:focus {
+    outline: none;
+    border-color: #644AC9;
+    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
   }
 }
 
-// 카테고리 모달
+.noCategory {
+  color: #94a3b8;
+}
+
 .categoryModal {
   position: absolute;
-  top: calc(100% + 0.5rem);
+  top: calc(100% + 4px);
   left: 0;
   width: 100%;
-  max-height: 400px;
   background-color: white;
-  border-radius: 8px;
+  border-radius: 6px;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  z-index: 100;
+  z-index: 50;
   border: 1px solid #e2e8f0;
   overflow: hidden;
+  max-height: 350px;
   display: flex;
   flex-direction: column;
 }
@@ -57,107 +52,71 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.5rem;
+  padding: 0.75rem 1rem;
   border-bottom: 1px solid #e2e8f0;
   
   h3 {
     margin: 0;
-    font-size: 1.1rem;
+    font-size: 1rem;
     font-weight: 600;
     color: #334155;
   }
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  border: none;
+  background-color: transparent;
+  color: #64748b;
+  cursor: pointer;
+  transition: all 0.2s ease;
   
-  .closeButton {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: none;
-    background-color: transparent;
-    color: #64748b;
-    cursor: pointer;
-    transition: background-color 0.2s ease;
-    
-    &:hover {
-      background-color: #f1f5f9;
-      color: #334155;
-    }
-    
-    &:focus {
-      outline: none;
-      box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
-    }
+  &:hover {
+    background-color: #f1f5f9;
+    color: #334155;
+  }
+  
+  &:focus {
+    outline: none;
   }
 }
 
 .searchContainer {
   position: relative;
-  padding: 1rem 1.5rem;
+  padding: 0.75rem 1rem;
   border-bottom: 1px solid #e2e8f0;
 }
 
 .searchInput {
   width: 100%;
-  padding: 0.75rem 1rem 0.75rem 2.5rem;
+  padding: 0.5rem 1rem 0.5rem 2rem;
   border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  font-size: 0.95rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  border-radius: 4px;
+  font-size: 0.9rem;
   
   &:focus {
     outline: none;
     border-color: #644AC9;
     box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
   }
-  
-  &::placeholder {
-    color: #94a3b8;
-  }
 }
 
 .searchIcon {
   position: absolute;
-  left: 2.25rem;
+  left: 1.5rem;
   top: 50%;
   transform: translateY(-50%);
   color: #94a3b8;
-  pointer-events: none;
-}
-
-.clearButton {
-  position: absolute;
-  right: 2.25rem;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  border: none;
-  background-color: #f1f5f9;
-  color: #64748b;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  
-  &:hover {
-    background-color: #e2e8f0;
-    color: #334155;
-  }
-  
-  &:focus {
-    outline: none;
-  }
 }
 
 .categoriesList {
-  padding: 0.5rem;
   overflow-y: auto;
-  flex: 1;
-  max-height: 250px;
+  max-height: 220px;
   
   &::-webkit-scrollbar {
     width: 6px;
@@ -174,12 +133,9 @@
 }
 
 .categoryItem {
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
+  padding: 0.5rem 1rem;
   cursor: pointer;
   transition: background-color 0.2s ease;
-  font-size: 0.95rem;
-  margin-bottom: 0.25rem;
   
   &:hover {
     background-color: #f1f5f9;
@@ -193,7 +149,7 @@
 }
 
 .noResults {
-  padding: 1.5rem;
+  padding: 1rem;
   text-align: center;
   color: #94a3b8;
   font-style: italic;

--- a/app/components/admin/markdown/CategorySelector.tsx
+++ b/app/components/admin/markdown/CategorySelector.tsx
@@ -28,7 +28,7 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
   const [searchTerm, setSearchTerm] = useState('');
   
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const modalRef = useRef<HTMLDivElement>(null);
+  const modalContentRef = useRef<HTMLDivElement>(null);
   
   // 필터링된 카테고리 목록
   const filteredCategories = sampleCategories.filter(cat => 
@@ -44,22 +44,27 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
   
   // 모달 열기/닫기 핸들러
   const toggleModal = () => {
-    setShowModal(prev => !prev);
-    setSearchTerm('');
-    
-    // 모달이 열리면 검색 입력란에 포커스
-    if (!showModal && searchInputRef.current) {
-      // 안정적인 포커스를 위해 setTimeout 사용
-      setTimeout(() => {
-        searchInputRef.current?.focus();
-      }, 10);
-    }
+    setShowModal(prev => {
+      const newState = !prev;
+      if (newState) {
+        // 모달이 열리면 body 스크롤 방지
+        document.body.style.overflow = 'hidden';
+        setSearchTerm(''); // 모달 열 때 검색어 초기화
+        setTimeout(() => {
+          searchInputRef.current?.focus();
+        }, 10);
+      } else {
+        // 모달이 닫히면 body 스크롤 복원
+        document.body.style.overflow = '';
+      }
+      return newState;
+    });
   };
   
   // 카테고리 선택 핸들러
   const handleCategorySelect = (categoryName: string) => {
     setCategory(categoryName);
-    setShowModal(false);
+    toggleModal(); // 카테고리 선택 후 모달 닫기
   };
   
   // 검색어 변경 핸들러
@@ -67,11 +72,17 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
     setSearchTerm(e.target.value);
   };
   
-  // 모달 외부 클릭 처리
+  // 모달 외부 클릭 처리 (모달 배경 클릭 시 닫기)
+  // 모달 내부 컨텐츠 클릭 시에는 닫히지 않도록 수정
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
-        setShowModal(false);
+      // modalContentRef.current가 존재하고, 클릭된 대상이 modalContentRef.current의 바깥 영역일 때만 모달을 닫음
+      if (showModal && modalContentRef.current && !modalContentRef.current.contains(event.target as Node)) {
+        // 직접 .categoryModal을 클릭했는지 확인 (더 정확한 외부 클릭 감지)
+        const modalElement = (event.target as HTMLElement).closest(`.${styles.categoryModal}`);
+        if (modalElement && event.target === modalElement) {
+          toggleModal();
+        }
       }
     };
     
@@ -81,13 +92,17 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
     
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      // 컴포넌트 언마운트 시 body 스크롤 복원 (만약 모달이 열린 상태로 페이지 이동 등)
+      if (document.body.style.overflow === 'hidden') {
+        document.body.style.overflow = '';
+      }
     };
-  }, [showModal]);
+  }, [showModal]); // toggleModal을 의존성 배열에서 제거 (무한 루프 방지)
   
   return (
     <div className={styles.categorySelector}>
       <button 
-        className={styles.categoryButton}
+        className={`${styles.categoryButton} ${showModal ? styles.modalOpen : ''}`}
         onClick={toggleModal}
         type="button"
       >
@@ -101,59 +116,61 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
       
       {/* 카테고리 선택 모달 */}
       {showModal && (
-        <div className={styles.categoryModal} ref={modalRef}>
-          <div className={styles.modalHeader}>
-            <h3>Select Category</h3>
-            <button 
-              className={styles.closeButton}
-              onClick={toggleModal}
-              aria-label="Close category selection"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18"></line>
-                <line x1="6" y1="6" x2="18" y2="18"></line>
-              </svg>
-            </button>
-          </div>
-          
-          <div className={styles.searchContainer}>
-            <input
-              type="text"
-              className={styles.searchInput}
-              placeholder="Search categories..."
-              value={searchTerm}
-              onChange={handleSearchChange}
-              ref={searchInputRef}
-            />
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={styles.searchIcon}>
-              <circle cx="11" cy="11" r="8"></circle>
-              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-            </svg>
-          </div>
-          
-          <div className={styles.categoriesList}>
-            <div
-              className={`${styles.categoryItem} ${category === 'No Category' ? styles.active : ''}`}
-              onClick={() => handleCategorySelect('No Category')}
-            >
-              No Category
+        <div className={styles.categoryModal}>
+          <div className={styles.modalContent} ref={modalContentRef}>
+            <div className={styles.modalHeader}>
+              <h3>Select Category</h3>
+              <button 
+                className={styles.closeButton}
+                onClick={toggleModal}
+                aria-label="Close category selection"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
             </div>
             
-            {filteredCategories.length > 0 ? (
-              filteredCategories.map(cat => (
-                <div
-                  key={cat.id}
-                  className={`${styles.categoryItem} ${category === cat.name ? styles.active : ''}`}
-                  onClick={() => handleCategorySelect(cat.name)}
-                >
-                  {cat.name}
-                </div>
-              ))
-            ) : (
-              <div className={styles.noResults}>
-                No categories found matching "{searchTerm}"
+            <div className={styles.searchContainer}>
+              <input
+                type="text"
+                className={styles.searchInput}
+                placeholder="Search categories..."
+                value={searchTerm}
+                onChange={handleSearchChange}
+                ref={searchInputRef}
+              />
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={styles.searchIcon}>
+                <circle cx="11" cy="11" r="8"></circle>
+                <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+              </svg>
+            </div>
+            
+            <div className={styles.categoriesList}>
+              <div
+                className={`${styles.categoryItem} ${category === 'No Category' ? styles.active : ''}`}
+                onClick={() => handleCategorySelect('No Category')}
+              >
+                No Category
               </div>
-            )}
+              
+              {filteredCategories.length > 0 ? (
+                filteredCategories.map(cat => (
+                  <div
+                    key={cat.id}
+                    className={`${styles.categoryItem} ${category === cat.name ? styles.active : ''}`}
+                    onClick={() => handleCategorySelect(cat.name)}
+                  >
+                    {cat.name}
+                  </div>
+                ))
+              ) : (
+                <div className={styles.noResults}>
+                  No categories found matching &quot;{searchTerm}&quot;
+                </div>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/app/components/admin/markdown/CategorySelector.tsx
+++ b/app/components/admin/markdown/CategorySelector.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import styles from './CategorySelector.module.scss';
+
+interface CategorySelectorProps {
+  initialCategory?: string;
+  onChange?: (category: string) => void;
+}
+
+// 테스트용 카테고리 샘플 데이터
+const sampleCategories = [
+  { id: 1, name: 'Programming' },
+  { id: 2, name: 'Web Development' },
+  { id: 3, name: 'JavaScript' },
+  { id: 4, name: 'React' },
+  { id: 5, name: 'Node.js' },
+  { id: 6, name: 'TypeScript' },
+  { id: 7, name: 'Python' },
+  { id: 8, name: 'DevOps' },
+  { id: 9, name: 'Database' },
+  { id: 10, name: 'Machine Learning' },
+];
+
+export default function CategorySelector({ initialCategory = 'No Category', onChange }: CategorySelectorProps) {
+  const [category, setCategory] = useState(initialCategory);
+  const [showModal, setShowModal] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [error, setError] = useState('');
+  const [showError, setShowError] = useState(false);
+  
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+  
+  // 필터링된 카테고리 목록
+  const filteredCategories = sampleCategories.filter(cat => 
+    cat.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+  
+  // 카테고리가 변경될 때 상위 컴포넌트에 알림
+  useEffect(() => {
+    if (onChange) {
+      onChange(category);
+    }
+  }, [category, onChange]);
+  
+  // 모달 열기/닫기 핸들러
+  const toggleModal = () => {
+    setShowModal(prev => !prev);
+    setSearchTerm('');
+    
+    // 모달이 열리면 검색 입력란에 포커스
+    if (!showModal && searchInputRef.current) {
+      // 안정적인 포커스를 위해 setTimeout 사용
+      setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 10);
+    }
+  };
+  
+  // 카테고리 선택 핸들러
+  const handleCategorySelect = (categoryName: string) => {
+    setCategory(categoryName);
+    setShowModal(false);
+  };
+  
+  // 검색어 변경 핸들러
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
+  };
+  
+  // 카테고리 유효성 검사
+  const validateCategory = () => {
+    if (category === 'No Category') {
+      setError('Please select a category');
+      setShowError(true);
+      return false;
+    }
+    
+    setError('');
+    return true;
+  };
+  
+  // 에러 모달 닫기
+  const handleCloseError = () => {
+    setShowError(false);
+  };
+  
+  // 모달 외부 클릭 처리
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        setShowModal(false);
+      }
+    };
+    
+    if (showModal) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showModal]);
+  
+  return (
+    <div className={styles.categorySelector}>
+      <div 
+        className={styles.selectedCategory}
+        onClick={toggleModal}
+      >
+        <span className={category === 'No Category' ? styles.noCategory : ''}>
+          {category}
+        </span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="m6 9 6 6 6-6"/>
+        </svg>
+      </div>
+      
+      {/* 카테고리 선택 모달 */}
+      {showModal && (
+        <div className={styles.categoryModal} ref={modalRef}>
+          <div className={styles.modalHeader}>
+            <h3>Select Category</h3>
+            <button 
+              className={styles.closeButton}
+              onClick={toggleModal}
+              aria-label="Close category selection"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </button>
+          </div>
+          
+          <div className={styles.searchContainer}>
+            <input
+              type="text"
+              className={styles.searchInput}
+              placeholder="Search categories..."
+              value={searchTerm}
+              onChange={handleSearchChange}
+              ref={searchInputRef}
+            />
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={styles.searchIcon}>
+              <circle cx="11" cy="11" r="8"></circle>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            </svg>
+            
+            {searchTerm && (
+              <button 
+                className={styles.clearButton}
+                onClick={() => setSearchTerm('')}
+                aria-label="Clear search"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            )}
+          </div>
+          
+          <div className={styles.categoriesList}>
+            <div
+              className={`${styles.categoryItem} ${category === 'No Category' ? styles.active : ''}`}
+              onClick={() => handleCategorySelect('No Category')}
+            >
+              No Category
+            </div>
+            
+            {filteredCategories.length > 0 ? (
+              filteredCategories.map(cat => (
+                <div
+                  key={cat.id}
+                  className={`${styles.categoryItem} ${category === cat.name ? styles.active : ''}`}
+                  onClick={() => handleCategorySelect(cat.name)}
+                >
+                  {cat.name}
+                </div>
+              ))
+            ) : (
+              <div className={styles.noResults}>
+                No categories found matching "{searchTerm}"
+              </div>
+            )}
+          </div>
+          
+          <div className={styles.modalFooter}>
+            <button 
+              className={styles.validateButton}
+              onClick={() => {
+                if (validateCategory()) {
+                  setShowModal(false);
+                }
+              }}
+            >
+              Confirm Selection
+            </button>
+          </div>
+        </div>
+      )}
+      
+      {/* 에러 모달 */}
+      {showError && error && (
+        <div className={styles.errorModal}>
+          <div className={styles.errorModalContent}>
+            <div className={styles.errorModalHeader}>
+              <h4>Error</h4>
+              <button 
+                className={styles.closeButton}
+                onClick={handleCloseError}
+                aria-label="Close error message"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            </div>
+            <div className={styles.errorMessage}>
+              {error}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/app/components/admin/markdown/CategorySelector.tsx
+++ b/app/components/admin/markdown/CategorySelector.tsx
@@ -103,7 +103,7 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
       {showModal && (
         <div className={styles.categoryModal} ref={modalRef}>
           <div className={styles.modalHeader}>
-            <h3>카테고리 선택</h3>
+            <h3>Select Category</h3>
             <button 
               className={styles.closeButton}
               onClick={toggleModal}
@@ -120,7 +120,7 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
             <input
               type="text"
               className={styles.searchInput}
-              placeholder="검색..."
+              placeholder="Search categories..."
               value={searchTerm}
               onChange={handleSearchChange}
               ref={searchInputRef}
@@ -151,7 +151,7 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
               ))
             ) : (
               <div className={styles.noResults}>
-                "{searchTerm}" 검색 결과가 없습니다
+                No categories found matching "{searchTerm}"
               </div>
             )}
           </div>

--- a/app/components/admin/markdown/CategorySelector.tsx
+++ b/app/components/admin/markdown/CategorySelector.tsx
@@ -26,8 +26,6 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
   const [category, setCategory] = useState(initialCategory);
   const [showModal, setShowModal] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
-  const [error, setError] = useState('');
-  const [showError, setShowError] = useState(false);
   
   const searchInputRef = useRef<HTMLInputElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -69,23 +67,6 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
     setSearchTerm(e.target.value);
   };
   
-  // 카테고리 유효성 검사
-  const validateCategory = () => {
-    if (category === 'No Category') {
-      setError('Please select a category');
-      setShowError(true);
-      return false;
-    }
-    
-    setError('');
-    return true;
-  };
-  
-  // 에러 모달 닫기
-  const handleCloseError = () => {
-    setShowError(false);
-  };
-  
   // 모달 외부 클릭 처리
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -105,23 +86,24 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
   
   return (
     <div className={styles.categorySelector}>
-      <div 
-        className={styles.selectedCategory}
+      <button 
+        className={styles.categoryButton}
         onClick={toggleModal}
+        type="button"
       >
         <span className={category === 'No Category' ? styles.noCategory : ''}>
           {category}
         </span>
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="m6 9 6 6 6-6"/>
         </svg>
-      </div>
+      </button>
       
       {/* 카테고리 선택 모달 */}
       {showModal && (
         <div className={styles.categoryModal} ref={modalRef}>
           <div className={styles.modalHeader}>
-            <h3>Select Category</h3>
+            <h3>카테고리 선택</h3>
             <button 
               className={styles.closeButton}
               onClick={toggleModal}
@@ -138,7 +120,7 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
             <input
               type="text"
               className={styles.searchInput}
-              placeholder="Search categories..."
+              placeholder="검색..."
               value={searchTerm}
               onChange={handleSearchChange}
               ref={searchInputRef}
@@ -147,19 +129,6 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
               <circle cx="11" cy="11" r="8"></circle>
               <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
             </svg>
-            
-            {searchTerm && (
-              <button 
-                className={styles.clearButton}
-                onClick={() => setSearchTerm('')}
-                aria-label="Clear search"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            )}
           </div>
           
           <div className={styles.categoriesList}>
@@ -182,46 +151,9 @@ export default function CategorySelector({ initialCategory = 'No Category', onCh
               ))
             ) : (
               <div className={styles.noResults}>
-                No categories found matching "{searchTerm}"
+                "{searchTerm}" 검색 결과가 없습니다
               </div>
             )}
-          </div>
-          
-          <div className={styles.modalFooter}>
-            <button 
-              className={styles.validateButton}
-              onClick={() => {
-                if (validateCategory()) {
-                  setShowModal(false);
-                }
-              }}
-            >
-              Confirm Selection
-            </button>
-          </div>
-        </div>
-      )}
-      
-      {/* 에러 모달 */}
-      {showError && error && (
-        <div className={styles.errorModal}>
-          <div className={styles.errorModalContent}>
-            <div className={styles.errorModalHeader}>
-              <h4>Error</h4>
-              <button 
-                className={styles.closeButton}
-                onClick={handleCloseError}
-                aria-label="Close error message"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div className={styles.errorMessage}>
-              {error}
-            </div>
           </div>
         </div>
       )}

--- a/app/components/admin/markdown/MarkdownEditor.module.scss
+++ b/app/components/admin/markdown/MarkdownEditor.module.scss
@@ -6,17 +6,33 @@
   background-color: white;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
   margin-top: 1rem;
+  transition: all 0.3s ease;
+  
+  &.fullscreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 9999;
+    border-radius: 0;
+    margin: 0;
+    border: none;
+  }
 }
 
 // 에디터 도구 영역
 .toolbar {
   display: flex;
   align-items: center;
-  padding: 0.5rem;
+  padding: 0.75rem;
   background-color: #f8fafc;
   border-bottom: 1px solid #e2e8f0;
   gap: 0.5rem;
   overflow-x: auto;
+  flex-wrap: wrap;
   
   &::-webkit-scrollbar {
     height: 6px;
@@ -38,7 +54,7 @@
   justify-content: center;
   min-width: 36px;
   height: 36px;
-  padding: 0 0.75rem;
+  padding: 0 0.5rem;
   border: 1px solid #e2e8f0;
   border-radius: 4px;
   background-color: white;
@@ -82,11 +98,21 @@
   grid-template-columns: 1fr 1fr;
   width: 100%;
   min-height: 500px;
+  max-height: calc(100vh - 120px);
+  
+  .fullscreen & {
+    max-height: calc(100vh - 72px);
+  }
 }
 
 .editorPane, .previewPane {
   width: 100%;
   min-height: 500px;
+  max-height: calc(100vh - 120px);
+  
+  .fullscreen & {
+    max-height: calc(100vh - 72px);
+  }
 }
 
 .editorPane {
@@ -167,6 +193,147 @@
   }
 }
 
+// 모달 스타일
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.modal {
+  width: 90%;
+  max-width: 600px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  
+  h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1F1F1F;
+  }
+  
+  .closeButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: none;
+    background-color: transparent;
+    color: #64748b;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    
+    &:hover {
+      background-color: #f1f5f9;
+      color: #334155;
+    }
+    
+    &:focus {
+      outline: none;
+    }
+  }
+}
+
+.modalBody {
+  padding: 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.modalContent {
+  p {
+    margin-top: 0;
+    color: #475569;
+    line-height: 1.6;
+  }
+  
+  code {
+    background-color: #f1f5f9;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    font-family: 'Menlo', 'Monaco', 'Consolas', monospace;
+    font-size: 0.9rem;
+    color: #334155;
+  }
+}
+
+.modalExample {
+  margin-top: 1.5rem;
+}
+
+.modalCodeBlock {
+  background-color: #f8fafc;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  overflow-x: auto;
+  border: 1px solid #e2e8f0;
+  
+  pre {
+    margin: 0;
+    
+    code {
+      background-color: transparent;
+      padding: 0;
+      font-family: 'Menlo', 'Monaco', 'Consolas', monospace;
+      font-size: 0.9rem;
+      color: #334155;
+      line-height: 1.6;
+    }
+  }
+}
+
+.buttonGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  
+  button {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    background-color: white;
+    color: #64748b;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    
+    &:hover {
+      border-color: #644AC9;
+      color: #644AC9;
+      background-color: #eff6ff;
+    }
+    
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+    }
+  }
+}
+
 // 반응형 스타일
 @media (max-width: 768px) {
   .editorContent {
@@ -184,22 +351,10 @@
   .toolbar {
     flex-wrap: wrap;
     justify-content: center;
+    padding: 0.5rem;
   }
   
   .mobileToggle {
     display: block;
-  }
-  
-  .toolbarCollapsible {
-    display: none;
-    width: 100%;
-    
-    &.expanded {
-      display: flex;
-      flex-wrap: wrap;
-      padding: 0.5rem;
-      gap: 0.5rem;
-      justify-content: flex-start;
-    }
   }
 } 

--- a/app/components/admin/markdown/MarkdownEditor.module.scss
+++ b/app/components/admin/markdown/MarkdownEditor.module.scss
@@ -1,12 +1,14 @@
 .editorContainer {
   width: 100%;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
   overflow: hidden;
   background-color: white;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  box-shadow: 
+    0 5px 15px rgba(0, 0, 0, 0.05),
+    0 1px 2px rgba(0, 0, 0, 0.03);
   margin-top: 1rem;
-  transition: all 0.3s ease;
+  transition: all 0.3s cubic-bezier(0.23, 1, 0.32, 1);
   
   &.fullscreen {
     position: fixed;
@@ -28,22 +30,37 @@
   display: flex;
   align-items: center;
   padding: 0.85rem;
-  background-color: #fcfaff;
-  border-bottom: 1px solid #eae5f5;
+  background: linear-gradient(to bottom, rgb(252, 252, 255), rgb(250, 249, 254));
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   gap: 0.6rem;
   overflow: visible;
   flex-wrap: wrap;
+  position: relative;
+  
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 1px;
+    background: linear-gradient(to right, 
+      rgba(255, 255, 255, 0),
+      rgba(255, 255, 255, 0.7),
+      rgba(255, 255, 255, 0)
+    );
+  }
   
   &::-webkit-scrollbar {
     height: 6px;
   }
   
   &::-webkit-scrollbar-track {
-    background: #f8f5ff;
+    background: rgba(248, 247, 254, 0.8);
   }
   
   &::-webkit-scrollbar-thumb {
-    background-color: #ddd6f3;
+    background-color: rgba(100, 74, 201, 0.15);
     border-radius: 3px;
   }
 }
@@ -55,31 +72,60 @@
   min-width: 36px;
   height: 36px;
   padding: 0 0.5rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  background-color: white;
-  color: #64748b;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  background-color: rgba(255, 255, 255, 0.85);
+  color: #555;
   font-size: 0.95rem;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all 0.2s cubic-bezier(0.23, 1, 0.32, 1);
+  position: relative;
+  overflow: hidden;
+  
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.5));
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    z-index: 0;
+  }
+  
+  svg {
+    position: relative;
+    z-index: 1;
+  }
   
   &:hover {
-    border-color: #644AC9;
-    background-color: #f8f5ff;
+    border-color: rgba(100, 74, 201, 0.3);
+    background-color: #fff;
     color: #644AC9;
     transform: translateY(-1px);
-    box-shadow: 0 3px 6px rgba(100, 74, 201, 0.1);
+    box-shadow: 
+      0 4px 10px -2px rgba(0, 0, 0, 0.07),
+      0 2px 4px -2px rgba(0, 0, 0, 0.05);
+    
+    &::before {
+      opacity: 1;
+    }
   }
   
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+    box-shadow: 
+      0 0 0 3px rgba(100, 74, 201, 0.15),
+      0 4px 8px -2px rgba(0, 0, 0, 0.1);
   }
   
   &.active {
-    background-color: #f0ecff;
-    border-color: #644AC9;
+    background-color: rgba(100, 74, 201, 0.1);
+    border-color: rgba(100, 74, 201, 0.3);
     color: #644AC9;
+    font-weight: 500;
   }
 }
 
@@ -385,41 +431,44 @@
 
 .tooltip {
   position: absolute;
-  top: 100%;
+  top: 120%;
   left: 50%;
-  margin-top: 5px;
-  transform: translateX(-50%);
+  transform: translateX(-50%) translateY(-10px);
   padding: 6px 10px;
-  background-color: rgba(250, 240, 255, 0.95);
-  backdrop-filter: blur(8px);
-  color: #644AC9;
-  font-size: 0.75rem;
-  font-weight: 500;
-  border-radius: 6px;
-  white-space: normal;
-  max-width: 180px;
-  min-width: 80px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(250, 245, 255, 0.95));
+  backdrop-filter: blur(10px);
+  color: #333;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: 8px;
+  white-space: nowrap;
+  min-width: 40px;
   text-align: center;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.12);
+  box-shadow: 
+    0 5px 15px -4px rgba(0, 0, 0, 0.1),
+    0 3px 8px -4px rgba(0, 0, 0, 0.07),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.7);
   z-index: 1000;
   opacity: 0;
   visibility: hidden;
-  transition: all 0.15s ease;
+  transition: all 0.2s cubic-bezier(0.23, 1, 0.32, 1);
   pointer-events: none;
-  border: 1px solid rgba(243, 214, 255, 0.8);
-  letter-spacing: 0.01em;
-  line-height: 1.4;
+  border: none;
+  letter-spacing: -0.01em;
+  line-height: 1.5;
+  transform-origin: top center;
   
   &::before {
     content: '';
     position: absolute;
-    top: -5px;
+    top: -6px;
     left: 50%;
     transform: translateX(-50%) rotate(45deg);
-    width: 10px;
-    height: 10px;
-    background-color: rgba(250, 240, 255, 0.95);
-    border-left: 1px solid rgba(243, 214, 255, 0.8);
-    border-top: 1px solid rgba(243, 214, 255, 0.8);
+    width: 12px;
+    height: 12px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(250, 245, 255, 0.95));
+    border: none;
+    border-radius: 2px;
+    box-shadow: -1px -1px 3px -1px rgba(0, 0, 0, 0.08);
   }
 } 

--- a/app/components/admin/markdown/MarkdownEditor.module.scss
+++ b/app/components/admin/markdown/MarkdownEditor.module.scss
@@ -27,11 +27,11 @@
 .toolbar {
   display: flex;
   align-items: center;
-  padding: 0.75rem;
-  background-color: #f8fafc;
-  border-bottom: 1px solid #e2e8f0;
-  gap: 0.5rem;
-  overflow-x: auto;
+  padding: 0.85rem;
+  background-color: #fcfaff;
+  border-bottom: 1px solid #eae5f5;
+  gap: 0.6rem;
+  overflow: visible;
   flex-wrap: wrap;
   
   &::-webkit-scrollbar {
@@ -39,11 +39,11 @@
   }
   
   &::-webkit-scrollbar-track {
-    background: #f8fafc;
+    background: #f8f5ff;
   }
   
   &::-webkit-scrollbar-thumb {
-    background-color: #e2e8f0;
+    background-color: #ddd6f3;
     border-radius: 3px;
   }
 }
@@ -56,7 +56,7 @@
   height: 36px;
   padding: 0 0.5rem;
   border: 1px solid #e2e8f0;
-  border-radius: 4px;
+  border-radius: 6px;
   background-color: white;
   color: #64748b;
   font-size: 0.95rem;
@@ -64,20 +64,22 @@
   transition: all 0.2s ease;
   
   &:hover {
-    border-color: #cbd5e1;
-    background-color: #f8fafc;
-    color: #334155;
+    border-color: #644AC9;
+    background-color: #f8f5ff;
+    color: #644AC9;
+    transform: translateY(-1px);
+    box-shadow: 0 3px 6px rgba(100, 74, 201, 0.1);
   }
   
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
   }
   
   &.active {
-    background-color: #eff6ff;
-    border-color: #93c5fd;
-    color: #2563eb;
+    background-color: #f0ecff;
+    border-color: #644AC9;
+    color: #644AC9;
   }
 }
 
@@ -362,46 +364,62 @@
 .tooltipWrapper {
   position: relative;
   display: inline-flex;
+  z-index: 50;
   
   &:hover {
     .tooltip {
       opacity: 1;
       visibility: visible;
-      transform: translateY(0);
     }
+  }
+
+  [data-tooltip-id] {
+    position: relative;
+  }
+
+  [data-tooltip-id]:hover + .tooltip {
+    opacity: 1;
+    visibility: visible;
   }
 }
 
 .tooltip {
   position: absolute;
-  bottom: -30px;
+  top: 100%;
   left: 50%;
-  transform: translateX(-50%) translateY(-5px);
-  padding: 4px 8px;
-  background-color: rgba(243, 244, 246, 0.85);
+  margin-top: 5px;
+  transform: translateX(-50%);
+  padding: 6px 10px;
+  background-color: rgba(250, 240, 255, 0.95);
   backdrop-filter: blur(8px);
-  color: #4b5563;
+  color: #644AC9;
   font-size: 0.75rem;
-  border-radius: 4px;
-  white-space: nowrap;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-  z-index: 10;
+  font-weight: 500;
+  border-radius: 6px;
+  white-space: normal;
+  max-width: 180px;
+  min-width: 80px;
+  text-align: center;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.12);
+  z-index: 1000;
   opacity: 0;
   visibility: hidden;
-  transition: all 0.2s ease;
+  transition: all 0.15s ease;
   pointer-events: none;
-  border: 1px solid rgba(229, 231, 235, 0.5);
+  border: 1px solid rgba(243, 214, 255, 0.8);
+  letter-spacing: 0.01em;
+  line-height: 1.4;
   
   &::before {
     content: '';
     position: absolute;
-    top: -4px;
+    top: -5px;
     left: 50%;
     transform: translateX(-50%) rotate(45deg);
-    width: 8px;
-    height: 8px;
-    background-color: rgba(243, 244, 246, 0.85);
-    border-left: 1px solid rgba(229, 231, 235, 0.5);
-    border-top: 1px solid rgba(229, 231, 235, 0.5);
+    width: 10px;
+    height: 10px;
+    background-color: rgba(250, 240, 255, 0.95);
+    border-left: 1px solid rgba(243, 214, 255, 0.8);
+    border-top: 1px solid rgba(243, 214, 255, 0.8);
   }
 } 

--- a/app/components/admin/markdown/MarkdownEditor.module.scss
+++ b/app/components/admin/markdown/MarkdownEditor.module.scss
@@ -357,4 +357,51 @@
   .mobileToggle {
     display: block;
   }
+}
+
+.tooltipWrapper {
+  position: relative;
+  display: inline-flex;
+  
+  &:hover {
+    .tooltip {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+  }
+}
+
+.tooltip {
+  position: absolute;
+  bottom: -30px;
+  left: 50%;
+  transform: translateX(-50%) translateY(-5px);
+  padding: 4px 8px;
+  background-color: rgba(243, 244, 246, 0.85);
+  backdrop-filter: blur(8px);
+  color: #4b5563;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.2s ease;
+  pointer-events: none;
+  border: 1px solid rgba(229, 231, 235, 0.5);
+  
+  &::before {
+    content: '';
+    position: absolute;
+    top: -4px;
+    left: 50%;
+    transform: translateX(-50%) rotate(45deg);
+    width: 8px;
+    height: 8px;
+    background-color: rgba(243, 244, 246, 0.85);
+    border-left: 1px solid rgba(229, 231, 235, 0.5);
+    border-top: 1px solid rgba(229, 231, 235, 0.5);
+  }
 } 

--- a/app/components/admin/markdown/MarkdownEditor.tsx
+++ b/app/components/admin/markdown/MarkdownEditor.tsx
@@ -26,6 +26,11 @@ interface ToolbarItem {
   onClick?: () => void;
 }
 
+// 코드미러 참조 타입 정의
+interface CodeMirrorRef {
+  view: EditorView;
+}
+
 export default function MarkdownEditor({ initialContent = '', onChange }: MarkdownEditorProps) {
   const [markdownContent, setMarkdownContent] = useState(initialContent);
   const [isMobile, setIsMobile] = useState(false);
@@ -35,7 +40,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
   const [showModal, setShowModal] = useState(false);
   const [modalContent, setModalContent] = useState<{ title: string, content: React.ReactNode }>({ title: '', content: null });
   
-  const codeMirrorRef = useRef<any>(null);
+  const codeMirrorRef = useRef<CodeMirrorRef | null>(null);
   
   // CodeMirror 확장 기능
   const extensions: Extension[] = [

--- a/app/components/admin/markdown/MarkdownEditor.tsx
+++ b/app/components/admin/markdown/MarkdownEditor.tsx
@@ -391,13 +391,19 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
             <button
               className={styles.toolbarButton}
               onClick={item.onClick}
-              title={item.label}
+              aria-label={item.label}
+              data-tooltip-id={`tooltip-${index}`}
             >
               {item.icon}
             </button>
-            <div className={styles.tooltip}>
+            <span className={styles.tooltip} id={`tooltip-${index}`} role="tooltip">
               {item.label}
-            </div>
+              {item.syntax && (
+                <span style={{ display: 'block', fontSize: '0.75rem', marginTop: '4px', opacity: 0.9 }}>
+                  {item.syntax.length > 30 ? item.syntax.substring(0, 30) + '...' : item.syntax}
+                </span>
+              )}
+            </span>
           </div>
         ))}
       </div>

--- a/app/components/admin/markdown/MarkdownEditor.tsx
+++ b/app/components/admin/markdown/MarkdownEditor.tsx
@@ -9,7 +9,7 @@ import { EditorView } from '@codemirror/view';
 import { Extension } from '@codemirror/state';
 import styles from './MarkdownEditor.module.scss';
 
-// 마크다운 렌더러를 동적으로 가져옵니다
+// Dynamically import the Markdown renderer
 const MarkdownRenderer = dynamic(() => import('@/app/components/markdown/MarkdownRenderer'), { 
   ssr: true 
 });
@@ -26,7 +26,7 @@ interface ToolbarItem {
   onClick?: () => void;
 }
 
-// 코드미러 참조 타입 정의
+// Define CodeMirror ref type
 interface CodeMirrorRef {
   view: EditorView;
 }
@@ -42,7 +42,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
   
   const codeMirrorRef = useRef<CodeMirrorRef | null>(null);
   
-  // CodeMirror 확장 기능
+  // CodeMirror extensions
   const extensions: Extension[] = [
     markdown({ 
       base: markdownLanguage, 
@@ -65,20 +65,20 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
     })
   ];
   
-  // 반응형 처리를 위한 useEffect
+  // useEffect for responsive handling
   useEffect(() => {
     const handleResize = () => {
       setIsMobile(window.innerWidth < 768);
     };
     
-    // 초기 설정
+    // Initial setup
     handleResize();
     
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
   
-  // 전체화면 이벤트 핸들러
+  // Fullscreen event handler
   useEffect(() => {
     const handleFullscreenChange = () => {
       setIsFullscreen(!!document.fullscreenElement);
@@ -88,7 +88,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
     return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
   }, []);
   
-  // 내용이 변경될 때마다 상위 컴포넌트에 알림
+  // Notify parent component whenever content changes
   useEffect(() => {
     if (onChange) {
       onChange(markdownContent);
@@ -99,7 +99,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
     setMarkdownContent(value);
   };
   
-  // 마크다운 문법 삽입 함수
+  // Function to insert Markdown syntax
   const insertMarkdown = (syntax: string) => {
     const editor = codeMirrorRef.current;
     
@@ -112,12 +112,12 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
       });
       dispatch(transaction);
     } else {
-      // CodeMirror 인스턴스가 없는 경우 기존 로직 사용
+      // Use existing logic if CodeMirror instance is not available
       setMarkdownContent(prevContent => prevContent + syntax);
     }
   };
   
-  // 마크다운 문법 아이콘 컴포넌트
+  // Markdown syntax icon components
   const HeadingIcon = () => (
     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M6 12h12"/>
@@ -232,7 +232,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
     </svg>
   );
   
-  // 툴바 버튼 목록
+  // Toolbar button list
   const toolbarItems: ToolbarItem[] = [
     { 
       label: 'Heading', 
@@ -243,17 +243,17 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
           title: 'Headings',
           content: (
             <div className={styles.modalContent}>
-              <p>마크다운에서는 <code>#</code> 기호를 사용하여 제목을 표시합니다. <code>#</code>의 개수에 따라 제목의 크기가 달라집니다.</p>
+              <p>In Markdown, use the <code>#</code> symbol to indicate headings. The number of <code>#</code> symbols determines the heading size.</p>
               <div className={styles.modalExample}>
                 <div className={styles.modalCodeBlock}>
                   <pre>
                     <code>
-                      # 제목 1<br/>
-                      ## 제목 2<br/>
-                      ### 제목 3<br/>
-                      #### 제목 4<br/>
-                      ###### 제목 5<br/>
-                      ###### 제목 6
+                      # Heading 1<br/>
+                      ## Heading 2<br/>
+                      ### Heading 3<br/>
+                      #### Heading 4<br/>
+                      ###### Heading 5<br/>
+                      ###### Heading 6
                     </code>
                   </pre>
                 </div>
@@ -337,7 +337,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
       icon: <ImageIcon />, 
       syntax: '![Image Alt Text](https://example.com/image.jpg)', 
       onClick: () => {
-        // 이미지 업로드 로직을 여기에 추가
+        // Add image upload logic here
         insertMarkdown('![Image Alt Text](https://example.com/image.jpg)');
       } 
     },
@@ -346,7 +346,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
       icon: <FileIcon />, 
       syntax: '[Download File](https://example.com/file.pdf)', 
       onClick: () => {
-        // 파일 업로드 로직을 여기에 추가
+        // Add file upload logic here
         insertMarkdown('[Download File](https://example.com/file.pdf)');
       } 
     },
@@ -367,14 +367,14 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
     },
   ];
   
-  // 모달 닫기 함수
+  // Function to close modal
   const closeModal = () => {
     setShowModal(false);
   };
   
   return (
     <div className={`${styles.editorContainer} ${isFullscreen ? styles.fullscreen : ''}`}>
-      {/* 모바일 환경에서 툴바 토글 버튼 */}
+      {/* Toolbar toggle button in mobile environment */}
       {isMobile && (
         <button 
           className={styles.mobileToggle}
@@ -384,7 +384,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
         </button>
       )}
       
-      {/* 툴바 */}
+      {/* Toolbar */}
       <div className={`${styles.toolbar} ${isMobile && !showToolbar ? styles.hidden : ''}`}>
         {toolbarItems.map((item, index) => (
           <div key={index} className={styles.tooltipWrapper}>
@@ -403,7 +403,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
         ))}
       </div>
       
-      {/* 모바일 탭 컨트롤 */}
+      {/* Mobile tab controls */}
       {isMobile && (
         <div className={styles.tabControls}>
           <button 
@@ -421,7 +421,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
         </div>
       )}
       
-      {/* 에디터 내용 */}
+      {/* Editor content */}
       <div className={styles.editorContent}>
         <div 
           className={`${styles.editorPane} ${
@@ -455,7 +455,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
         </div>
       </div>
       
-      {/* 문법 도움말 모달 */}
+      {/* Syntax help modal */}
       {showModal && (
         <div className={styles.modalOverlay} onClick={closeModal}>
           <div className={styles.modal} onClick={(e) => e.stopPropagation()}>

--- a/app/components/admin/markdown/MarkdownEditor.tsx
+++ b/app/components/admin/markdown/MarkdownEditor.tsx
@@ -382,14 +382,18 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
       {/* 툴바 */}
       <div className={`${styles.toolbar} ${isMobile && !showToolbar ? styles.hidden : ''}`}>
         {toolbarItems.map((item, index) => (
-          <button
-            key={index}
-            className={styles.toolbarButton}
-            onClick={item.onClick}
-            title={item.label}
-          >
-            {item.icon}
-          </button>
+          <div key={index} className={styles.tooltipWrapper}>
+            <button
+              className={styles.toolbarButton}
+              onClick={item.onClick}
+              title={item.label}
+            >
+              {item.icon}
+            </button>
+            <div className={styles.tooltip}>
+              {item.label}
+            </div>
+          </div>
         ))}
       </div>
       

--- a/app/components/admin/markdown/MarkdownEditor.tsx
+++ b/app/components/admin/markdown/MarkdownEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import CodeMirror from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
@@ -19,11 +19,23 @@ interface MarkdownEditorProps {
   onChange?: (content: string) => void;
 }
 
+interface ToolbarItem {
+  label: string;
+  icon: React.ReactNode;
+  syntax: string;
+  onClick?: () => void;
+}
+
 export default function MarkdownEditor({ initialContent = '', onChange }: MarkdownEditorProps) {
   const [markdownContent, setMarkdownContent] = useState(initialContent);
   const [isMobile, setIsMobile] = useState(false);
   const [activeTab, setActiveTab] = useState<'editor' | 'preview'>('editor');
   const [showToolbar, setShowToolbar] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [modalContent, setModalContent] = useState<{ title: string, content: React.ReactNode }>({ title: '', content: null });
+  
+  const codeMirrorRef = useRef<any>(null);
   
   // CodeMirror 확장 기능
   const extensions: Extension[] = [
@@ -61,6 +73,16 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
     return () => window.removeEventListener('resize', handleResize);
   }, []);
   
+  // 전체화면 이벤트 핸들러
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
+  
   // 내용이 변경될 때마다 상위 컴포넌트에 알림
   useEffect(() => {
     if (onChange) {
@@ -73,30 +95,280 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
   };
   
   // 마크다운 문법 삽입 함수
-  const insertMarkdown = (markdownSyntax: string) => {
-    // CodeMirror를 직접 제어할 수 없으므로 현재 상태를 기반으로 새 콘텐츠 생성
-    setMarkdownContent(prevContent => {
-      // 매우 기본적인 구현 - 실제로는 커서 위치를 고려해야 함
-      return prevContent + markdownSyntax;
-    });
+  const insertMarkdown = (syntax: string) => {
+    const editor = codeMirrorRef.current;
+    
+    if (editor) {
+      const { state, dispatch } = editor.view;
+      const { from, to } = state.selection.main;
+      const transaction = state.update({
+        changes: { from, to, insert: syntax },
+        selection: { anchor: from + syntax.length }
+      });
+      dispatch(transaction);
+    } else {
+      // CodeMirror 인스턴스가 없는 경우 기존 로직 사용
+      setMarkdownContent(prevContent => prevContent + syntax);
+    }
   };
   
+  // 마크다운 문법 아이콘 컴포넌트
+  const HeadingIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 12h12"/>
+      <path d="M6 20V4"/>
+      <path d="M18 20V4"/>
+    </svg>
+  );
+  
+  const BoldIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14 12a4 4 0 0 0 0-8H6v8"/>
+      <path d="M15 20a4 4 0 0 0 0-8H6v8Z"/>
+    </svg>
+  );
+  
+  const ItalicIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="19" x2="10" y1="4" y2="4"/>
+      <line x1="14" x2="5" y1="20" y2="20"/>
+      <line x1="15" x2="9" y1="4" y2="20"/>
+    </svg>
+  );
+  
+  const StrikethroughIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 16a4 4 0 1 0 8 0 4 4 0 0 0-8 0z"/>
+      <path d="M8.5 8A4 4 0 0 1 19 8"/>
+      <path d="M3 12h18"/>
+    </svg>
+  );
+  
+  const ListIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="8" x2="21" y1="6" y2="6"/>
+      <line x1="8" x2="21" y1="12" y2="12"/>
+      <line x1="8" x2="21" y1="18" y2="18"/>
+      <line x1="3" x2="3" y1="6" y2="6"/>
+      <line x1="3" x2="3" y1="12" y2="12"/>
+      <line x1="3" x2="3" y1="18" y2="18"/>
+    </svg>
+  );
+  
+  const NumberedListIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="10" x2="21" y1="6" y2="6"/>
+      <line x1="10" x2="21" y1="12" y2="12"/>
+      <line x1="10" x2="21" y1="18" y2="18"/>
+      <path d="M4 6h1v4"/>
+      <path d="M4 10h2"/>
+      <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1"/>
+    </svg>
+  );
+  
+  const QuoteIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2H4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-1 2-2 2s-1 .008-1 1.031V20c0 1 0 1 1 1z"/>
+      <path d="M15 21c3 0 7-1 7-8V5c0-1.25-.757-2.017-2-2h-4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2h.75c0 2.25.25 4-2.75 4v3c0 1 0 1 1 1z"/>
+    </svg>
+  );
+  
+  const CodeIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="16 18 22 12 16 6"/>
+      <polyline points="8 6 2 12 8 18"/>
+    </svg>
+  );
+  
+  const LinkIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+    </svg>
+  );
+  
+  const TableIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/>
+      <line x1="3" x2="21" y1="9" y2="9"/>
+      <line x1="3" x2="21" y1="15" y2="15"/>
+      <line x1="9" x2="9" y1="3" y2="21"/>
+      <line x1="15" x2="15" y1="3" y2="21"/>
+    </svg>
+  );
+  
+  const HorizontalRuleIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="3" x2="21" y1="12" y2="12"/>
+    </svg>
+  );
+  
+  const ImageIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/>
+      <circle cx="9" cy="9" r="2"/>
+      <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>
+    </svg>
+  );
+  
+  const FileIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/>
+      <polyline points="14 2 14 8 20 8"/>
+    </svg>
+  );
+  
+  const FullscreenIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M8 3H5a2 2 0 0 0-2 2v3"/>
+      <path d="M21 8V5a2 2 0 0 0-2-2h-3"/>
+      <path d="M3 16v3a2 2 0 0 0 2 2h3"/>
+      <path d="M16 21h3a2 2 0 0 0 2-2v-3"/>
+    </svg>
+  );
+  
   // 툴바 버튼 목록
-  const toolbarItems = [
-    { label: 'H1', syntax: '# Heading 1\n', onClick: () => insertMarkdown('# Heading 1\n') },
-    { label: 'H2', syntax: '## Heading 2\n', onClick: () => insertMarkdown('## Heading 2\n') },
-    { label: 'H3', syntax: '### Heading 3\n', onClick: () => insertMarkdown('### Heading 3\n') },
-    { label: 'Bold', syntax: '**Bold text**', onClick: () => insertMarkdown('**Bold text**') },
-    { label: 'Italic', syntax: '*Italic text*', onClick: () => insertMarkdown('*Italic text*') },
-    { label: 'Link', syntax: '[Link text](https://example.com)', onClick: () => insertMarkdown('[Link text](https://example.com)') },
-    { label: 'List', syntax: '\n- List item\n', onClick: () => insertMarkdown('\n- List item\n') },
-    { label: 'Quote', syntax: '\n> Blockquote\n', onClick: () => insertMarkdown('\n> Blockquote\n') },
-    { label: 'Code', syntax: '\n```javascript\n// Your code here\n```\n', onClick: () => insertMarkdown('\n```javascript\n// Your code here\n```\n') },
-    { label: 'Table', syntax: '\n| Header 1 | Header 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |\n', onClick: () => insertMarkdown('\n| Header 1 | Header 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |\n') },
+  const toolbarItems: ToolbarItem[] = [
+    { 
+      label: 'Heading', 
+      icon: <HeadingIcon />, 
+      syntax: '# Heading 1\n', 
+      onClick: () => {
+        setModalContent({
+          title: 'Headings',
+          content: (
+            <div className={styles.modalContent}>
+              <p>마크다운에서는 <code>#</code> 기호를 사용하여 제목을 표시합니다. <code>#</code>의 개수에 따라 제목의 크기가 달라집니다.</p>
+              <div className={styles.modalExample}>
+                <div className={styles.modalCodeBlock}>
+                  <pre>
+                    <code>
+                      # 제목 1<br/>
+                      ## 제목 2<br/>
+                      ### 제목 3<br/>
+                      #### 제목 4<br/>
+                      ###### 제목 5<br/>
+                      ###### 제목 6
+                    </code>
+                  </pre>
+                </div>
+                <div className={styles.buttonGroup}>
+                  <button onClick={() => insertMarkdown('# Heading 1\n')}>H1</button>
+                  <button onClick={() => insertMarkdown('## Heading 2\n')}>H2</button>
+                  <button onClick={() => insertMarkdown('### Heading 3\n')}>H3</button>
+                  <button onClick={() => insertMarkdown('#### Heading 4\n')}>H4</button>
+                  <button onClick={() => insertMarkdown('##### Heading 5\n')}>H5</button>
+                  <button onClick={() => insertMarkdown('###### Heading 6\n')}>H6</button>
+                </div>
+              </div>
+            </div>
+          )
+        });
+        setShowModal(true);
+      }
+    },
+    { 
+      label: 'Bold', 
+      icon: <BoldIcon />, 
+      syntax: '**Bold Text**', 
+      onClick: () => insertMarkdown('**Bold Text**') 
+    },
+    { 
+      label: 'Italic', 
+      icon: <ItalicIcon />, 
+      syntax: '*Italic Text*', 
+      onClick: () => insertMarkdown('*Italic Text*') 
+    },
+    { 
+      label: 'Strikethrough', 
+      icon: <StrikethroughIcon />, 
+      syntax: '~~Strikethrough~~', 
+      onClick: () => insertMarkdown('~~Strikethrough~~') 
+    },
+    { 
+      label: 'List', 
+      icon: <ListIcon />, 
+      syntax: '\n- List item 1\n- List item 2\n- List item 3\n', 
+      onClick: () => insertMarkdown('\n- List item 1\n- List item 2\n- List item 3\n') 
+    },
+    { 
+      label: 'Numbered List', 
+      icon: <NumberedListIcon />, 
+      syntax: '\n1. First item\n2. Second item\n3. Third item\n', 
+      onClick: () => insertMarkdown('\n1. First item\n2. Second item\n3. Third item\n') 
+    },
+    { 
+      label: 'Quote', 
+      icon: <QuoteIcon />, 
+      syntax: '\n> Blockquote text\n', 
+      onClick: () => insertMarkdown('\n> Blockquote text\n') 
+    },
+    { 
+      label: 'Code', 
+      icon: <CodeIcon />, 
+      syntax: '\n```javascript\n// Your code here\n```\n', 
+      onClick: () => insertMarkdown('\n```javascript\n// Your code here\n```\n') 
+    },
+    { 
+      label: 'Link', 
+      icon: <LinkIcon />, 
+      syntax: '[Link text](https://example.com)', 
+      onClick: () => insertMarkdown('[Link text](https://example.com)') 
+    },
+    { 
+      label: 'Table', 
+      icon: <TableIcon />, 
+      syntax: '\n| Header 1 | Header 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |\n', 
+      onClick: () => insertMarkdown('\n| Header 1 | Header 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |\n') 
+    },
+    { 
+      label: 'Horizontal Rule', 
+      icon: <HorizontalRuleIcon />, 
+      syntax: '\n---\n', 
+      onClick: () => insertMarkdown('\n---\n') 
+    },
+    { 
+      label: 'Image', 
+      icon: <ImageIcon />, 
+      syntax: '![Image Alt Text](https://example.com/image.jpg)', 
+      onClick: () => {
+        // 이미지 업로드 로직을 여기에 추가
+        insertMarkdown('![Image Alt Text](https://example.com/image.jpg)');
+      } 
+    },
+    { 
+      label: 'File', 
+      icon: <FileIcon />, 
+      syntax: '[Download File](https://example.com/file.pdf)', 
+      onClick: () => {
+        // 파일 업로드 로직을 여기에 추가
+        insertMarkdown('[Download File](https://example.com/file.pdf)');
+      } 
+    },
+    { 
+      label: 'Fullscreen', 
+      icon: <FullscreenIcon />, 
+      syntax: '', 
+      onClick: () => {
+        const editorContainer = document.querySelector(`.${styles.editorContainer}`);
+        if (!isFullscreen && editorContainer) {
+          if (editorContainer.requestFullscreen) {
+            editorContainer.requestFullscreen();
+          }
+        } else if (document.exitFullscreen) {
+          document.exitFullscreen();
+        }
+      } 
+    },
   ];
   
+  // 모달 닫기 함수
+  const closeModal = () => {
+    setShowModal(false);
+  };
+  
   return (
-    <div className={styles.editorContainer}>
+    <div className={`${styles.editorContainer} ${isFullscreen ? styles.fullscreen : ''}`}>
       {/* 모바일 환경에서 툴바 토글 버튼 */}
       {isMobile && (
         <button 
@@ -109,44 +381,16 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
       
       {/* 툴바 */}
       <div className={`${styles.toolbar} ${isMobile && !showToolbar ? styles.hidden : ''}`}>
-        <div className={styles.toolbarGroup}>
-          {toolbarItems.slice(0, 3).map((item, index) => (
-            <button
-              key={index}
-              className={styles.toolbarButton}
-              onClick={item.onClick}
-              title={item.label}
-            >
-              {item.label}
-            </button>
-          ))}
-        </div>
-        
-        <div className={styles.toolbarGroup}>
-          {toolbarItems.slice(3, 6).map((item, index) => (
-            <button
-              key={index}
-              className={styles.toolbarButton}
-              onClick={item.onClick}
-              title={item.label}
-            >
-              {item.label}
-            </button>
-          ))}
-        </div>
-        
-        <div className={styles.toolbarGroup}>
-          {toolbarItems.slice(6).map((item, index) => (
-            <button
-              key={index}
-              className={styles.toolbarButton}
-              onClick={item.onClick}
-              title={item.label}
-            >
-              {item.label}
-            </button>
-          ))}
-        </div>
+        {toolbarItems.map((item, index) => (
+          <button
+            key={index}
+            className={styles.toolbarButton}
+            onClick={item.onClick}
+            title={item.label}
+          >
+            {item.icon}
+          </button>
+        ))}
       </div>
       
       {/* 모바일 탭 컨트롤 */}
@@ -188,6 +432,7 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
               autocompletion: true
             }}
             className={styles.codeMirrorWrapper}
+            ref={codeMirrorRef}
           />
         </div>
         
@@ -199,6 +444,26 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
           <MarkdownRenderer content={markdownContent} />
         </div>
       </div>
+      
+      {/* 문법 도움말 모달 */}
+      {showModal && (
+        <div className={styles.modalOverlay} onClick={closeModal}>
+          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h3>{modalContent.title}</h3>
+              <button className={styles.closeButton} onClick={closeModal}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 6 6 18"/>
+                  <path d="m6 6 12 12"/>
+                </svg>
+              </button>
+            </div>
+            <div className={styles.modalBody}>
+              {modalContent.content}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 } 

--- a/app/components/admin/markdown/MarkdownEditor.tsx
+++ b/app/components/admin/markdown/MarkdownEditor.tsx
@@ -398,11 +398,6 @@ export default function MarkdownEditor({ initialContent = '', onChange }: Markdo
             </button>
             <span className={styles.tooltip} id={`tooltip-${index}`} role="tooltip">
               {item.label}
-              {item.syntax && (
-                <span style={{ display: 'block', fontSize: '0.75rem', marginTop: '4px', opacity: 0.9 }}>
-                  {item.syntax.length > 30 ? item.syntax.substring(0, 30) + '...' : item.syntax}
-                </span>
-              )}
             </span>
           </div>
         ))}

--- a/app/components/admin/markdown/TagsInput.module.scss
+++ b/app/components/admin/markdown/TagsInput.module.scss
@@ -1,0 +1,371 @@
+.tagsInputContainer {
+  margin-bottom: 1.5rem;
+  width: 100%;
+}
+
+.tagsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+  
+  h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #334155;
+    margin: 0;
+  }
+}
+
+.manageButton {
+  padding: 0.5rem 0.75rem;
+  background-color: #eff6ff;
+  color: #644AC9;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  
+  &:hover {
+    background-color: #dbeafe;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+  }
+}
+
+.tagsInput {
+  position: relative;
+  width: 100%;
+}
+
+.selectedTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  min-height: 50px;
+  background-color: white;
+}
+
+.tag {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  background-color: #eff6ff;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  color: #644AC9;
+  
+  span {
+    font-weight: 500;
+  }
+  
+  &:hover {
+    .removeTag {
+      opacity: 1;
+    }
+  }
+}
+
+.removeTag {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background-color: transparent;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  opacity: 0.5;
+  padding: 0;
+  
+  &:hover {
+    color: #644AC9;
+  }
+  
+  &:focus {
+    outline: none;
+    opacity: 1;
+  }
+}
+
+.tagInput {
+  flex: 1;
+  min-width: 100px;
+  border: none;
+  outline: none;
+  font-size: 0.95rem;
+  padding: 0.25rem;
+  background-color: transparent;
+  
+  &::placeholder {
+    color: #94a3b8;
+  }
+}
+
+// 태그 자동완성
+.suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  max-height: 200px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  z-index: 50;
+  overflow-y: auto;
+  margin-top: 0.5rem;
+  border: 1px solid #e2e8f0;
+  
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: #f8fafc;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background-color: #e2e8f0;
+    border-radius: 3px;
+  }
+}
+
+.suggestionItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  
+  &:hover {
+    background-color: #f1f5f9;
+  }
+  
+  &:not(:last-child) {
+    border-bottom: 1px solid #f1f5f9;
+  }
+}
+
+.tagName {
+  font-weight: 500;
+  color: #334155;
+}
+
+.tagCount {
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.tagsInfo {
+  margin-top: 0.5rem;
+  
+  p {
+    font-size: 0.85rem;
+    color: #94a3b8;
+    margin: 0;
+  }
+  
+  kbd {
+    display: inline-block;
+    padding: 0.1rem 0.35rem;
+    background-color: #f1f5f9;
+    border-radius: 3px;
+    border: 1px solid #e2e8f0;
+    font-size: 0.8rem;
+    font-family: monospace;
+    color: #64748b;
+  }
+}
+
+// 태그 관리 모달
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  width: 90%;
+  max-width: 600px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  
+  h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #334155;
+  }
+  
+  .closeButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: none;
+    background-color: transparent;
+    color: #64748b;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    
+    &:hover {
+      background-color: #f1f5f9;
+      color: #334155;
+    }
+    
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+    }
+  }
+}
+
+.modalBody {
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  overflow-y: auto;
+  
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+  }
+  
+  h4 {
+    margin-top: 0;
+    font-size: 1rem;
+    color: #334155;
+    margin-bottom: 1rem;
+  }
+}
+
+.tagsList, .selectedTagsList {
+  display: flex;
+  flex-direction: column;
+}
+
+.allTags, .selectedTagsItems {
+  flex: 1;
+  overflow-y: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  max-height: 250px;
+  
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: #f8fafc;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background-color: #e2e8f0;
+    border-radius: 3px;
+  }
+}
+
+.tagListItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  
+  &:not(:last-child) {
+    border-bottom: 1px solid #f1f5f9;
+  }
+}
+
+.removeTagButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: none;
+  background-color: #f1f5f9;
+  color: #64748b;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  
+  &:hover {
+    background-color: #fee2e2;
+    color: #b91c1c;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.2);
+  }
+}
+
+.noTags {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.modalFooter {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.doneButton {
+  padding: 0.75rem 1.5rem;
+  background-color: #644AC9;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  
+  &:hover {
+    background-color: #5038af;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+  }
+} 

--- a/app/components/admin/markdown/TagsInput.tsx
+++ b/app/components/admin/markdown/TagsInput.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import styles from './TagsInput.module.scss';
+
+interface TagsInputProps {
+  initialTags?: string[];
+  onChange?: (tags: string[]) => void;
+}
+
+// 태그 자동완성을 위한 샘플 데이터
+const sampleTags = [
+  { id: 1, name: '#javascript', count: 15 },
+  { id: 2, name: '#react', count: 12 },
+  { id: 3, name: '#typescript', count: 8 },
+  { id: 4, name: '#nextjs', count: 10 },
+  { id: 5, name: '#webdev', count: 20 },
+  { id: 6, name: '#frontend', count: 7 },
+  { id: 7, name: '#backend', count: 5 },
+  { id: 8, name: '#api', count: 3 },
+  { id: 9, name: '#database', count: 9 },
+  { id: 10, name: '#css', count: 11 },
+];
+
+export default function TagsInput({ initialTags = [], onChange }: TagsInputProps) {
+  const [tags, setTags] = useState<string[]>(initialTags);
+  const [inputValue, setInputValue] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  
+  const inputRef = useRef<HTMLInputElement>(null);
+  const suggestionRef = useRef<HTMLDivElement>(null);
+  
+  // 필터링된 태그 자동완성 목록
+  const filteredSuggestions = sampleTags.filter(tag => 
+    tag.name.toLowerCase().includes(inputValue.toLowerCase()) &&
+    !tags.includes(tag.name)
+  );
+  
+  // 태그가 변경될 때 상위 컴포넌트에 알림
+  useEffect(() => {
+    if (onChange) {
+      onChange(tags);
+    }
+  }, [tags, onChange]);
+  
+  // 태그 추가 함수
+  const addTag = (tag: string) => {
+    let newTag = tag.trim();
+    
+    // 입력값이 없으면 무시
+    if (newTag === '') return;
+    
+    // # 접두사 자동 추가
+    if (!newTag.startsWith('#')) {
+      newTag = `#${newTag}`;
+    }
+    
+    // 중복 태그 방지
+    if (!tags.includes(newTag)) {
+      setTags([...tags, newTag]);
+    }
+    
+    // 입력란 초기화
+    setInputValue('');
+    setShowSuggestions(false);
+    
+    // 입력란에 포커스
+    inputRef.current?.focus();
+  };
+  
+  // 태그 제거 함수
+  const removeTag = (index: number) => {
+    setTags(tags.filter((_, i) => i !== index));
+  };
+  
+  // 입력값 변경 핸들러
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setInputValue(value);
+    
+    // 입력값이 있을 때만 자동완성 표시
+    setShowSuggestions(value !== '');
+  };
+  
+  // 키보드 입력 핸들러
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Enter 키로 태그 추가
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addTag(inputValue);
+    }
+    
+    // 백스페이스 키로 마지막 태그 제거 (입력값이 비어있을 때만)
+    else if (e.key === 'Backspace' && inputValue === '' && tags.length > 0) {
+      removeTag(tags.length - 1);
+    }
+  };
+  
+  // 자동완성 항목 클릭 핸들러
+  const handleSuggestionClick = (tag: string) => {
+    addTag(tag);
+  };
+  
+  // 태그 모달 열기
+  const openTagsModal = () => {
+    setShowModal(true);
+  };
+  
+  // 태그 모달 닫기
+  const closeTagsModal = () => {
+    setShowModal(false);
+  };
+  
+  // 모달 외부 클릭 처리
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (suggestionRef.current && !suggestionRef.current.contains(event.target as Node) && 
+          inputRef.current && !inputRef.current.contains(event.target as Node)) {
+        setShowSuggestions(false);
+      }
+    };
+    
+    if (showSuggestions) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showSuggestions]);
+  
+  return (
+    <div className={styles.tagsInputContainer}>
+      <div className={styles.tagsHeader}>
+        <h3>Tags</h3>
+        <button 
+          className={styles.manageButton}
+          onClick={openTagsModal}
+          type="button"
+        >
+          Manage Tags
+        </button>
+      </div>
+      
+      <div className={styles.tagsInput}>
+        <div className={styles.selectedTags}>
+          {tags.map((tag, index) => (
+            <div key={index} className={styles.tag}>
+              <span>{tag}</span>
+              <button 
+                type="button"
+                className={styles.removeTag}
+                onClick={() => removeTag(index)}
+                aria-label={`Remove tag ${tag}`}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            </div>
+          ))}
+          
+          <input
+            type="text"
+            className={styles.tagInput}
+            value={inputValue}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            placeholder={tags.length === 0 ? "Add tags..." : ""}
+            ref={inputRef}
+          />
+        </div>
+        
+        {/* 태그 자동완성 */}
+        {showSuggestions && filteredSuggestions.length > 0 && (
+          <div className={styles.suggestions} ref={suggestionRef}>
+            {filteredSuggestions.map((tag) => (
+              <div 
+                key={tag.id} 
+                className={styles.suggestionItem}
+                onClick={() => handleSuggestionClick(tag.name)}
+              >
+                <span className={styles.tagName}>{tag.name}</span>
+                <span className={styles.tagCount}>{tag.count} posts</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      
+      <div className={styles.tagsInfo}>
+        <p>Press <kbd>Enter</kbd> to add a tag. Tags must start with #.</p>
+      </div>
+      
+      {/* 태그 관리 모달 */}
+      {showModal && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modal}>
+            <div className={styles.modalHeader}>
+              <h3>Manage Tags</h3>
+              <button 
+                className={styles.closeButton}
+                onClick={closeTagsModal}
+                aria-label="Close tag management"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            </div>
+            
+            <div className={styles.modalBody}>
+              <div className={styles.tagsList}>
+                <h4>All Tags</h4>
+                <div className={styles.allTags}>
+                  {sampleTags.map((tag) => (
+                    <div key={tag.id} className={styles.tagListItem}>
+                      <span className={styles.tagName}>{tag.name}</span>
+                      <span className={styles.tagCount}>{tag.count} posts</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              
+              <div className={styles.selectedTagsList}>
+                <h4>Selected Tags</h4>
+                {tags.length > 0 ? (
+                  <div className={styles.selectedTagsItems}>
+                    {tags.map((tag, index) => (
+                      <div key={index} className={styles.tagListItem}>
+                        <span className={styles.tagName}>{tag}</span>
+                        <button 
+                          className={styles.removeTagButton}
+                          onClick={() => removeTag(index)}
+                          aria-label={`Remove tag ${tag}`}
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <line x1="18" y1="6" x2="6" y2="18"></line>
+                            <line x1="6" y1="6" x2="18" y2="18"></line>
+                          </svg>
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className={styles.noTags}>No tags selected</p>
+                )}
+              </div>
+            </div>
+            
+            <div className={styles.modalFooter}>
+              <button 
+                className={styles.doneButton}
+                onClick={closeTagsModal}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/app/components/admin/markdown/TagsInput.tsx
+++ b/app/components/admin/markdown/TagsInput.tsx
@@ -133,13 +133,13 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
   return (
     <div className={styles.tagsInputContainer}>
       <div className={styles.tagsHeader}>
-        <h3>태그</h3>
+        <h3>Tags</h3>
         <button 
           className={styles.manageButton}
           onClick={openTagsModal}
           type="button"
         >
-          태그 관리
+          Manage Tags
         </button>
       </div>
       
@@ -168,7 +168,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
             value={inputValue}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
-            placeholder={tags.length === 0 ? "태그 추가..." : ""}
+            placeholder={tags.length === 0 ? "Add tags..." : ""}
             ref={inputRef}
           />
         </div>
@@ -191,7 +191,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
       </div>
       
       <div className={styles.tagsInfo}>
-        <p><kbd>Enter</kbd> 키를 눌러 태그를 추가하세요. 태그는 #으로 시작해야 합니다.</p>
+        <p>Press <kbd>Enter</kbd> to add a tag. Tags must start with #.</p>
       </div>
       
       {/* 태그 관리 모달 */}
@@ -199,11 +199,11 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
         <div className={styles.modalOverlay}>
           <div className={styles.modal}>
             <div className={styles.modalHeader}>
-              <h3>태그 관리</h3>
+              <h3>Manage Tags</h3>
               <button 
                 className={styles.closeButton}
                 onClick={closeTagsModal}
-                aria-label="태그 관리 닫기"
+                aria-label="Close tag management"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <line x1="18" y1="6" x2="6" y2="18"></line>
@@ -214,19 +214,19 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
             
             <div className={styles.modalBody}>
               <div className={styles.tagsList}>
-                <h4>모든 태그</h4>
+                <h4>All Tags</h4>
                 <div className={styles.allTags}>
                   {sampleTags.map((tag) => (
                     <div key={tag.id} className={styles.tagListItem}>
                       <span className={styles.tagName}>{tag.name}</span>
-                      <span className={styles.tagCount}>{tag.count} 개의 글</span>
+                      <span className={styles.tagCount}>{tag.count} posts</span>
                     </div>
                   ))}
                 </div>
               </div>
               
               <div className={styles.selectedTagsList}>
-                <h4>선택된 태그</h4>
+                <h4>Selected Tags</h4>
                 {tags.length > 0 ? (
                   <div className={styles.selectedTagsItems}>
                     {tags.map((tag, index) => (
@@ -235,7 +235,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
                         <button 
                           className={styles.removeTagButton}
                           onClick={() => removeTag(index)}
-                          aria-label={`${tag} 태그 제거`}
+                          aria-label={`Remove tag ${tag}`}
                         >
                           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                             <line x1="18" y1="6" x2="6" y2="18"></line>
@@ -246,7 +246,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
                     ))}
                   </div>
                 ) : (
-                  <p className={styles.noTags}>선택된 태그가 없습니다</p>
+                  <p className={styles.noTags}>No tags selected</p>
                 )}
               </div>
             </div>
@@ -256,7 +256,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
                 className={styles.doneButton}
                 onClick={closeTagsModal}
               >
-                완료
+                Done
               </button>
             </div>
           </div>

--- a/app/components/admin/markdown/TagsInput.tsx
+++ b/app/components/admin/markdown/TagsInput.tsx
@@ -133,13 +133,13 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
   return (
     <div className={styles.tagsInputContainer}>
       <div className={styles.tagsHeader}>
-        <h3>Tags</h3>
+        <h3>태그</h3>
         <button 
           className={styles.manageButton}
           onClick={openTagsModal}
           type="button"
         >
-          Manage Tags
+          태그 관리
         </button>
       </div>
       
@@ -168,7 +168,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
             value={inputValue}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
-            placeholder={tags.length === 0 ? "Add tags..." : ""}
+            placeholder={tags.length === 0 ? "태그 추가..." : ""}
             ref={inputRef}
           />
         </div>
@@ -191,7 +191,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
       </div>
       
       <div className={styles.tagsInfo}>
-        <p>Press <kbd>Enter</kbd> to add a tag. Tags must start with #.</p>
+        <p><kbd>Enter</kbd> 키를 눌러 태그를 추가하세요. 태그는 #으로 시작해야 합니다.</p>
       </div>
       
       {/* 태그 관리 모달 */}
@@ -199,11 +199,11 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
         <div className={styles.modalOverlay}>
           <div className={styles.modal}>
             <div className={styles.modalHeader}>
-              <h3>Manage Tags</h3>
+              <h3>태그 관리</h3>
               <button 
                 className={styles.closeButton}
                 onClick={closeTagsModal}
-                aria-label="Close tag management"
+                aria-label="태그 관리 닫기"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <line x1="18" y1="6" x2="6" y2="18"></line>
@@ -214,19 +214,19 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
             
             <div className={styles.modalBody}>
               <div className={styles.tagsList}>
-                <h4>All Tags</h4>
+                <h4>모든 태그</h4>
                 <div className={styles.allTags}>
                   {sampleTags.map((tag) => (
                     <div key={tag.id} className={styles.tagListItem}>
                       <span className={styles.tagName}>{tag.name}</span>
-                      <span className={styles.tagCount}>{tag.count} posts</span>
+                      <span className={styles.tagCount}>{tag.count} 개의 글</span>
                     </div>
                   ))}
                 </div>
               </div>
               
               <div className={styles.selectedTagsList}>
-                <h4>Selected Tags</h4>
+                <h4>선택된 태그</h4>
                 {tags.length > 0 ? (
                   <div className={styles.selectedTagsItems}>
                     {tags.map((tag, index) => (
@@ -235,7 +235,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
                         <button 
                           className={styles.removeTagButton}
                           onClick={() => removeTag(index)}
-                          aria-label={`Remove tag ${tag}`}
+                          aria-label={`${tag} 태그 제거`}
                         >
                           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                             <line x1="18" y1="6" x2="6" y2="18"></line>
@@ -246,7 +246,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
                     ))}
                   </div>
                 ) : (
-                  <p className={styles.noTags}>No tags selected</p>
+                  <p className={styles.noTags}>선택된 태그가 없습니다</p>
                 )}
               </div>
             </div>
@@ -256,7 +256,7 @@ export default function TagsInput({ initialTags = [], onChange }: TagsInputProps
                 className={styles.doneButton}
                 onClick={closeTagsModal}
               >
-                Done
+                완료
               </button>
             </div>
           </div>

--- a/app/components/admin/markdown/TitleInput.module.scss
+++ b/app/components/admin/markdown/TitleInput.module.scss
@@ -1,0 +1,113 @@
+.titleInputContainer {
+  position: relative;
+  margin-bottom: 1.5rem;
+  width: 100%;
+}
+
+.titleInput {
+  width: 100%;
+  padding: 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  
+  &:focus {
+    outline: none;
+    border-color: #644AC9;
+    box-shadow: 0 0 0 2px rgba(100, 74, 201, 0.2);
+  }
+  
+  &::placeholder {
+    color: #94a3b8;
+    font-weight: 400;
+  }
+  
+  &.hasError {
+    border-color: #e53e3e;
+    
+    &:focus {
+      box-shadow: 0 0 0 2px rgba(229, 62, 62, 0.2);
+    }
+  }
+}
+
+.titleCounter {
+  position: absolute;
+  right: 1rem;
+  bottom: -1.5rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.warningCount {
+  color: #f59e0b;
+}
+
+// 에러 모달
+.errorModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.errorModalContent {
+  width: 90%;
+  max-width: 400px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.errorModalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  background-color: #fee2e2;
+  color: #b91c1c;
+  
+  h4 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+  
+  .closeButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: none;
+    background-color: transparent;
+    color: #b91c1c;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    
+    &:hover {
+      background-color: rgba(185, 28, 28, 0.1);
+    }
+    
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.2);
+    }
+  }
+}
+
+.errorMessage {
+  padding: 1.5rem;
+  color: #4b5563;
+  font-size: 1rem;
+  line-height: 1.5;
+} 

--- a/app/components/admin/markdown/TitleInput.tsx
+++ b/app/components/admin/markdown/TitleInput.tsx
@@ -6,9 +6,10 @@ import styles from './TitleInput.module.scss';
 interface TitleInputProps {
   initialTitle?: string;
   onChange?: (title: string) => void;
+  onValidate?: (isValid: boolean, errorMessage: string) => void;
 }
 
-export default function TitleInput({ initialTitle = '', onChange }: TitleInputProps) {
+export default function TitleInput({ initialTitle = '', onChange, onValidate }: TitleInputProps) {
   const [title, setTitle] = useState(initialTitle);
   const [error, setError] = useState('');
   const [showError, setShowError] = useState(false);
@@ -20,8 +21,12 @@ export default function TitleInput({ initialTitle = '', onChange }: TitleInputPr
     }
     
     // 실시간 유효성 검사를 위한 로직 (선택적)
-    validateTitle(title, false);
-  }, [title, onChange]);
+    const isValid = validateTitle(title, false);
+    
+    if (onValidate) {
+      onValidate(isValid, error);
+    }
+  }, [title, onChange, onValidate, error]);
   
   // 제목 변경 핸들러
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -29,7 +34,7 @@ export default function TitleInput({ initialTitle = '', onChange }: TitleInputPr
   };
   
   // 제목 유효성 검사
-  const validateTitle = (value: string, showErrorMessage = true) => {
+  const validateTitle = (value: string, showErrorMessage = false) => {
     if (value.trim() === '') {
       setError('Title cannot be empty');
       if (showErrorMessage) setShowError(true);
@@ -46,14 +51,14 @@ export default function TitleInput({ initialTitle = '', onChange }: TitleInputPr
     return true;
   };
   
-  // 포커스를 잃었을 때 유효성 검사
-  const handleBlur = () => {
-    validateTitle(title, true);
-  };
-  
   // 에러 모달 닫기
   const handleCloseError = () => {
     setShowError(false);
+  };
+  
+  // 외부에서 에러 표시를 트리거하는 메소드 (ref를 통해 호출 가능)
+  const showErrorMessage = () => {
+    validateTitle(title, true);
   };
   
   return (
@@ -63,7 +68,6 @@ export default function TitleInput({ initialTitle = '', onChange }: TitleInputPr
         className={`${styles.titleInput} ${error ? styles.hasError : ''}`}
         value={title}
         onChange={handleTitleChange}
-        onBlur={handleBlur}
         placeholder="Enter post title..."
         aria-label="Post title"
         maxLength={255}

--- a/app/components/admin/markdown/TitleInput.tsx
+++ b/app/components/admin/markdown/TitleInput.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import styles from './TitleInput.module.scss';
+
+interface TitleInputProps {
+  initialTitle?: string;
+  onChange?: (title: string) => void;
+}
+
+export default function TitleInput({ initialTitle = '', onChange }: TitleInputProps) {
+  const [title, setTitle] = useState(initialTitle);
+  const [error, setError] = useState('');
+  const [showError, setShowError] = useState(false);
+  
+  // 제목이 변경될 때 상위 컴포넌트에 알림
+  useEffect(() => {
+    if (onChange) {
+      onChange(title);
+    }
+    
+    // 실시간 유효성 검사를 위한 로직 (선택적)
+    validateTitle(title, false);
+  }, [title, onChange]);
+  
+  // 제목 변경 핸들러
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+  
+  // 제목 유효성 검사
+  const validateTitle = (value: string, showErrorMessage = true) => {
+    if (value.trim() === '') {
+      setError('Title cannot be empty');
+      if (showErrorMessage) setShowError(true);
+      return false;
+    }
+    
+    if (value.length > 255) {
+      setError('Title must be 255 characters or less');
+      if (showErrorMessage) setShowError(true);
+      return false;
+    }
+    
+    setError('');
+    return true;
+  };
+  
+  // 포커스를 잃었을 때 유효성 검사
+  const handleBlur = () => {
+    validateTitle(title, true);
+  };
+  
+  // 에러 모달 닫기
+  const handleCloseError = () => {
+    setShowError(false);
+  };
+  
+  return (
+    <div className={styles.titleInputContainer}>
+      <input
+        type="text"
+        className={`${styles.titleInput} ${error ? styles.hasError : ''}`}
+        value={title}
+        onChange={handleTitleChange}
+        onBlur={handleBlur}
+        placeholder="Enter post title..."
+        aria-label="Post title"
+        maxLength={255}
+      />
+      
+      {/* 제목 길이 카운터 */}
+      <div className={styles.titleCounter}>
+        <span className={title.length > 200 ? styles.warningCount : ''}>
+          {title.length}
+        </span> / 255
+      </div>
+      
+      {/* 에러 모달 */}
+      {showError && error && (
+        <div className={styles.errorModal}>
+          <div className={styles.errorModalContent}>
+            <div className={styles.errorModalHeader}>
+              <h4>Error</h4>
+              <button 
+                className={styles.closeButton}
+                onClick={handleCloseError}
+                aria-label="Close error message"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            </div>
+            <div className={styles.errorMessage}>
+              {error}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+} 


### PR DESCRIPTION
# 어드민 대시보드 및 마크다운 에디터 구현

## 개요
이 PR은 관리자 페이지의 기본 구조와 마크다운 에디터 기능을 구현한 내용을 포함합니다. 이슈 #7에서 요구한 관리자 대시보드 및 마크다운 에디터 기능을 구현했습니다.

## 주요 변경사항

### 관리자 레이아웃
- 어드민 레이아웃 구조 구현 (`app/components/admin/layout/Layout.tsx`)
- 사이드바 컴포넌트 구현 (토글 기능 포함)
- 헤더 컴포넌트 구현 (검색, 알림, 프로필 메뉴 포함)
- 반응형 디자인 적용 (모바일 대응)

### 마크다운 에디터
- CodeMirror 기반 마크다운 에디터 구현
- 실시간 마크다운 미리보기 기능
- 전체화면 모드 지원
- 마크다운 문법 도구모음(툴바) 구현
- 모달 형태의 마크다운 문법 가이드 제공

### 블로그 포스트 메타데이터 관리
- 제목 입력 컴포넌트 (문자 수 제한 및 유효성 검사)
- 카테고리 선택 컴포넌트 (모달 형태의 카테고리 선택 UI)
- 태그 입력/관리 시스템 (자동 완성 및 태그 추가/삭제 기능)

## 테스트
- 모든 컴포넌트의 기본 기능 동작 확인
- 반응형 디자인 모바일/데스크톱 호환성 테스트
- 마크다운 에디터 문법 및 렌더링 테스트

## 스크린샷
![image](https://github.com/user-attachments/assets/f34d4a28-3a28-4d5d-98b0-497b0e067e50)
![image](https://github.com/user-attachments/assets/707fee65-3e33-465e-8aa5-4de8b2af0a6f)
![image](https://github.com/user-attachments/assets/8998fc7d-85c9-4cf4-9386-e2a05ead9ac5)

