### PR TITLE
Fix: Add local class to resolve pure global selector issue in CSS Module

### DIFF
--- a/app/(global)/blog/page.module.scss
+++ b/app/(global)/blog/page.module.scss
@@ -1,3 +1,7 @@
+.globals {
+  /* Added local class to meet CSS Module requirements */
+}
+
 :global(html) {
   scrollbar-gutter: stable;
   overflow-y: scroll;


### PR DESCRIPTION
This commit adds a local class to the blog page module to fix the build error where pure global selectors were causing compilation to fail. CSS Modules require at least one local class or ID in the file.