### PR TITLE
fix: separate global styles from CSS modules

### DIFF
--- a/app/(global)/blog/page.module.scss
+++ b/app/(global)/blog/page.module.scss
@@ -1,29 +1,5 @@
 .globals {
-  /* Added local class to meet CSS Module requirements */
-}
-
-:global(html) {
-  scrollbar-gutter: stable;
-  overflow-y: scroll;
-}
-
-:global(*::-webkit-scrollbar) {
-  width: 6px;
-  height: 6px;
-}
-
-:global(*::-webkit-scrollbar-track) {
-  background: transparent;
-}
-
-:global(*::-webkit-scrollbar-thumb) {
-  background-color: rgba(0, 0, 0, 0.1);
-  border-radius: 6px;
-}
-
-:global(*) {
-  scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.1) transparent;
+  /* Local class to meet CSS Module requirements */
 }
 
 .container {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,24 @@
+/* Global scrollbar styles */
+html {
+  scrollbar-gutter: stable;
+  overflow-y: scroll;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 6px;
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.1) transparent;
+} 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,5 @@
+import './globals.css';
+
 export default function RootLayout({
   children,
 }: {


### PR DESCRIPTION
This commit resolves the production build error related to CSS modules by:
- Moving global styles from page.module.scss to a separate globals.css file
- Adding the required import in the root layout component
- Maintaining a local class in the module to meet CSS module requirements

The change ensures proper styling whilst maintaining compatibility with Next.js CSS module processing during production builds.