### PR TITLE
improve blog UI/UX and add documentation for card model switching

### DIFF
--- a/app/(global)/blog/page.module.scss
+++ b/app/(global)/blog/page.module.scss
@@ -43,7 +43,7 @@
   grid-template-columns: 280px 1fr;
   gap: 2rem;
   position: relative;
-  padding-top: calc(70px + 1rem);
+  padding-top: calc(70px + 3rem);
   transform: translateZ(0);
   will-change: auto;
   contain: layout;
@@ -55,7 +55,7 @@
   
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
-    padding-top: calc(60px + 1rem);
+    padding-top: calc(60px + 2.5rem);
   }
 }
 

--- a/app/(global)/blog/post/[id]/page.module.scss
+++ b/app/(global)/blog/post/[id]/page.module.scss
@@ -1,0 +1,328 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: calc(70px + 3rem) 1rem 2rem;
+  
+  @media (max-width: 768px) {
+    padding: calc(60px + 2.5rem) 1rem 1rem;
+  }
+}
+
+// Breadcrumb Navigation
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  font-size: 0.9rem;
+  color: #666;
+  flex-wrap: wrap;
+}
+
+.breadcrumbLink {
+  color: #666;
+  text-decoration: none;
+  transition: color 0.2s ease;
+  
+  &:hover {
+    color: #fda4af;
+  }
+}
+
+.breadcrumbSeparator {
+  color: #ccc;
+  margin: 0 0.25rem;
+}
+
+.breadcrumbCurrent {
+  color: #333;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+  
+  @media (max-width: 768px) {
+    max-width: 150px;
+  }
+}
+
+// Article Header
+.articleHeader {
+  margin-bottom: 3rem;
+  
+  @media (max-width: 768px) {
+    margin-bottom: 2rem;
+  }
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+.tag {
+  background-color: #f8f9fa;
+  color: #555;
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+  
+  &:hover {
+    background-color: #fda4af;
+    color: white;
+    border-color: #fda4af;
+  }
+}
+
+.title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #1a1a1a;
+  margin: 0 0 1.5rem;
+  
+  @media (max-width: 768px) {
+    font-size: 2rem;
+  }
+  
+  @media (max-width: 480px) {
+    font-size: 1.75rem;
+  }
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  
+  @media (max-width: 768px) {
+    gap: 1rem;
+    flex-direction: column;
+  }
+}
+
+.metaItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.metaLabel {
+  font-size: 0.75rem;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+}
+
+.metaValue {
+  font-size: 0.9rem;
+  color: #333;
+  font-weight: 500;
+}
+
+.authorInfo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.authorAvatar {
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.categoryLink {
+  font-size: 0.9rem;
+  color: #fda4af;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+  
+  &:hover {
+    color: #f87171;
+  }
+}
+
+.coverImageContainer {
+  position: relative;
+  width: 100%;
+  height: 400px;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 2rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  
+  @media (max-width: 768px) {
+    height: 250px;
+    margin-bottom: 1.5rem;
+  }
+}
+
+.coverImage {
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+// Article Content
+.articleContent {
+  margin-bottom: 4rem;
+  
+  // Override some markdown styles for better article layout
+  :global(.markdownContent) {
+    font-size: 1.1rem;
+    line-height: 1.8;
+    
+    @media (max-width: 768px) {
+      font-size: 1rem;
+      line-height: 1.7;
+    }
+    
+    h1 {
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+    }
+    
+    h2 {
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+    }
+    
+    h3 {
+      margin-top: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    
+    p {
+      margin-bottom: 1.5rem;
+    }
+    
+    ul, ol {
+      margin-bottom: 1.5rem;
+    }
+    
+    blockquote {
+      margin: 2rem 0;
+      padding: 1rem 1.5rem;
+      border-left: 4px solid #fda4af;
+      background-color: #fef7f7;
+      border-radius: 0 8px 8px 0;
+    }
+    
+    pre {
+      margin: 2rem 0;
+      border-radius: 8px;
+    }
+    
+    img {
+      border-radius: 8px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    }
+  }
+}
+
+// Post Navigation
+.postNavigation {
+  margin-bottom: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid #eee;
+}
+
+.navigationGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+
+.navCard {
+  display: block;
+  padding: 1.5rem;
+  border: 1px solid #eee;
+  border-radius: 12px;
+  text-decoration: none;
+  transition: all 0.3s ease;
+  background-color: #fff;
+  
+  &:hover {
+    border-color: #fda4af;
+    box-shadow: 0 4px 12px rgba(253, 164, 175, 0.1);
+    transform: translateY(-2px);
+  }
+  
+  &:only-child {
+    grid-column: span 2;
+    max-width: 400px;
+    margin: 0 auto;
+    
+    @media (max-width: 768px) {
+      grid-column: span 1;
+      max-width: none;
+    }
+  }
+}
+
+.navDirection {
+  font-size: 0.8rem;
+  color: #fda4af;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.5rem;
+}
+
+.navTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.navMeta {
+  font-size: 0.8rem;
+  color: #666;
+}
+
+// Back to Blog
+.backToBlog {
+  text-align: center;
+  padding-top: 2rem;
+  border-top: 1px solid #eee;
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background-color: #f8f9fa;
+  color: #666;
+  text-decoration: none;
+  border-radius: 8px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  
+  &:hover {
+    background-color: #fda4af;
+    color: white;
+  }
+} 

--- a/app/(global)/blog/post/[id]/page.tsx
+++ b/app/(global)/blog/post/[id]/page.tsx
@@ -1,0 +1,299 @@
+import { notFound } from 'next/navigation';
+import { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+import { 
+  getPostNoAuthorById, 
+  getAdjacentPostsNoAuthor,
+  getPostById,
+  getAdjacentPosts,
+  getCategoryById 
+} from '@/app/data/blogData';
+import MarkdownRenderer from '@/app/components/markdown/MarkdownRenderer';
+import { formatDate } from '@/app/lib/utils';
+import styles from './page.module.scss';
+
+// Configuration: Set to true to show author information
+const SHOW_AUTHOR_INFO = false;
+
+type PageProps = {
+  params: { id: string }
+};
+
+// Generate metadata for SEO
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const postId = parseInt(params.id, 10);
+  const post = SHOW_AUTHOR_INFO ? getPostById(postId) : getPostNoAuthorById(postId);
+  
+  if (!post) {
+    return {
+      title: 'Post Not Found',
+      description: 'The requested blog post could not be found.'
+    };
+  }
+  
+  const category = getCategoryById(post.categoryId);
+  
+  return {
+    title: `${post.title} - DokaLab Blog`,
+    description: post.excerpt,
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      type: 'article',
+      publishedTime: post.publishedAt,
+      authors: SHOW_AUTHOR_INFO && 'author' in post ? [(post as any).author.name] : ['DokaLab'],
+      tags: post.tags.map(tag => tag.name),
+      images: post.coverImage ? [{ url: post.coverImage, alt: post.title }] : undefined,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt,
+      images: post.coverImage ? [post.coverImage] : undefined,
+    },
+    keywords: [
+      ...post.tags.map(tag => tag.name),
+      category?.name || '',
+      'DokaLab',
+      'Tech Blog',
+      'Programming',
+      'Development'
+    ].filter(Boolean),
+  };
+}
+
+export default function BlogPostPage({ params }: PageProps) {
+  const postId = parseInt(params.id, 10);
+  
+  // Validate ID
+  if (isNaN(postId)) {
+    notFound();
+  }
+  
+  const post = SHOW_AUTHOR_INFO ? getPostById(postId) : getPostNoAuthorById(postId);
+  
+  if (!post) {
+    notFound();
+  }
+  
+  const category = getCategoryById(post.categoryId);
+  const { previous, next } = SHOW_AUTHOR_INFO ? getAdjacentPosts(postId) : getAdjacentPostsNoAuthor(postId);
+  
+  // Generate sample markdown content since we only have Lorem ipsum
+  const sampleMarkdownContent = 
+`## Introduction
+
+This is a comprehensive guide that covers the essential concepts and practical applications. Whether you're a beginner or an experienced developer, this article will provide valuable insights and actionable knowledge.
+
+## Key Concepts
+
+### Understanding the Fundamentals
+
+The foundation of any successful implementation lies in understanding the core principles. Let's explore the key concepts that will guide our approach:
+
+- **Concept 1**: Essential building blocks that form the foundation
+- **Concept 2**: Advanced techniques for optimization
+- **Concept 3**: Best practices for maintainable code
+
+### Practical Implementation
+
+Here's how you can apply these concepts in real-world scenarios:
+
+\`\`\`javascript
+// Example implementation
+function exampleFunction() {
+  console.log("This is a sample code block");
+  return "Hello, World!";
+}
+
+// Usage
+const result = exampleFunction();
+console.log(result);
+\`\`\`
+
+## Advanced Techniques
+
+:::tip
+This is a helpful tip that provides additional context and guidance for better understanding.
+:::
+
+:::warning
+Be careful when implementing these techniques in production environments. Always test thoroughly.
+:::
+
+### Performance Considerations
+
+When working with these technologies, consider the following performance optimizations:
+
+1. **Optimization Strategy 1**: Detailed explanation of the first strategy
+2. **Optimization Strategy 2**: How to implement the second approach
+3. **Optimization Strategy 3**: Advanced techniques for maximum efficiency
+
+## Mathematical Concepts
+
+Sometimes we need to express complex relationships using mathematical notation:
+
+The fundamental equation can be expressed as: $E = mc^2$
+
+For more complex calculations:
+
+$$
+\\sum_{i=1}^{n} x_i = x_1 + x_2 + \\cdots + x_n
+$$
+
+## Conclusion
+
+This comprehensive overview provides the foundation you need to get started. Remember to practice these concepts and experiment with different approaches to find what works best for your specific use case.
+
+### Next Steps
+
+- [ ] Practice the basic concepts
+- [ ] Implement a simple project
+- [ ] Explore advanced features
+- [ ] Share your learnings with the community
+
+## Additional Resources
+
+For further reading and deeper understanding, check out these resources:
+
+- [Official Documentation](https://example.com)
+- [Community Forum](https://example.com)
+- [Advanced Tutorials](https://example.com)
+
+---
+
+*Thank you for reading! If you found this article helpful, please share it with others who might benefit from this knowledge.*`;
+
+  return (
+    <div className={styles.container}>
+      {/* Breadcrumb Navigation */}
+      <nav className={styles.breadcrumb}>
+        {category && (
+          <>
+            <Link 
+              href={`/blog?category=${category.id}`} 
+              className={styles.breadcrumbLink}
+            >
+              {category.name}
+            </Link>
+            <span className={styles.breadcrumbSeparator}>&gt;</span>
+          </>
+        )}
+        <span className={styles.breadcrumbCurrent}>{post.title}</span>
+      </nav>
+
+      {/* Article Header */}
+      <header className={styles.articleHeader}>
+        {/* Title */}
+        <h1 className={styles.title}>{post.title}</h1>
+
+        {/* Meta Information */}
+        <div className={styles.meta}>
+          {SHOW_AUTHOR_INFO && 'author' in post && (
+            <div className={styles.metaItem}>
+              <span className={styles.metaLabel}>Author</span>
+              <div className={styles.authorInfo}>
+                <Image
+                  src={(post as any).author.avatar}
+                  alt={(post as any).author.name}
+                  width={24}
+                  height={24}
+                  className={styles.authorAvatar}
+                />
+                <span className={styles.metaValue}>{(post as any).author.name}</span>
+              </div>
+            </div>
+          )}
+          <div className={styles.metaItem}>
+            <span className={styles.metaLabel}>Published</span>
+            <time className={styles.metaValue}>{formatDate(post.publishedAt)}</time>
+          </div>
+          <div className={styles.metaItem}>
+            <span className={styles.metaLabel}>Reading Time</span>
+            <span className={styles.metaValue}>{post.readingTime} min read</span>
+          </div>
+          {category && (
+            <div className={styles.metaItem}>
+              <span className={styles.metaLabel}>Category</span>
+              <Link 
+                href={`/blog?category=${category.id}`}
+                className={styles.categoryLink}
+              >
+                {category.name}
+              </Link>
+            </div>
+          )}
+        </div>
+
+        {/* Tags */}
+        {post.tags && post.tags.length > 0 && (
+          <div className={styles.tags}>
+            {post.tags.map((tag) => (
+              <Link
+                key={tag.id}
+                href={`/blog?tag=${tag.id}`}
+                className={styles.tag}
+              >
+                {tag.name}
+              </Link>
+            ))}
+          </div>
+        )}
+
+        {/* Cover Image */}
+        {post.coverImage && (
+          <div className={styles.coverImageContainer}>
+            <Image
+              src={post.coverImage}
+              alt={post.title}
+              fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 1200px"
+              className={styles.coverImage}
+              priority
+            />
+          </div>
+        )}
+      </header>
+
+      {/* Article Content */}
+      <article className={styles.articleContent}>
+        <MarkdownRenderer content={sampleMarkdownContent} />
+      </article>
+
+      {/* Navigation to Previous/Next Posts */}
+      {(previous || next) && (
+        <nav className={styles.postNavigation}>
+          <div className={styles.navigationGrid}>
+            {previous && (
+              <Link href={`/blog/post/${previous.id}`} className={styles.navCard}>
+                <div className={styles.navDirection}>← Previous</div>
+                <div className={styles.navTitle}>{previous.title}</div>
+                <div className={styles.navMeta}>
+                  {formatDate(previous.publishedAt)} • {previous.readingTime} min read
+                </div>
+              </Link>
+            )}
+            
+            {next && (
+              <Link href={`/blog/post/${next.id}`} className={styles.navCard}>
+                <div className={styles.navDirection}>Next →</div>
+                <div className={styles.navTitle}>{next.title}</div>
+                <div className={styles.navMeta}>
+                  {formatDate(next.publishedAt)} • {next.readingTime} min read
+                </div>
+              </Link>
+            )}
+          </div>
+        </nav>
+      )}
+
+      {/* Back to Blog Link */}
+      <div className={styles.backToBlog}>
+        <Link href="/blog" className={styles.backLink}>
+          ← Back to All Posts
+        </Link>
+      </div>
+    </div>
+  );
+} 

--- a/app/components/blog/BlogPostCard.module.scss
+++ b/app/components/blog/BlogPostCard.module.scss
@@ -16,7 +16,6 @@
   
   &:hover {
     box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-    transform: translateY(-5px) translateZ(0);
     
     .coverImage {
       transform: scale(1.05);

--- a/app/components/blog/BlogPostCardNoAuthor.module.scss
+++ b/app/components/blog/BlogPostCardNoAuthor.module.scss
@@ -16,7 +16,6 @@
   
   &:hover {
     box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
-    transform: translateY(-5px) translateZ(0);
     
     .coverImage {
       transform: scale(1.05);

--- a/app/data/blogData.ts
+++ b/app/data/blogData.ts
@@ -495,4 +495,42 @@ export function getPostsNoAuthorByTagId(tagId: number) {
   return blogPostsNoAuthor.filter(post => 
     post.tags.some(tag => tag.id === tagId)
   );
+}
+
+// Function to get a single post by ID (with author)
+export function getPostById(id: number) {
+  return blogPosts.find(post => post.id === id);
+}
+
+// Function to get a single post by ID (without author)
+export function getPostNoAuthorById(id: number) {
+  return blogPostsNoAuthor.find(post => post.id === id);
+}
+
+// Function to get previous and next posts (with author)
+export function getAdjacentPosts(currentId: number) {
+  const sortedPosts = [...blogPosts].sort((a, b) => 
+    new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+  );
+  
+  const currentIndex = sortedPosts.findIndex(post => post.id === currentId);
+  
+  return {
+    previous: currentIndex > 0 ? sortedPosts[currentIndex - 1] : null,
+    next: currentIndex < sortedPosts.length - 1 ? sortedPosts[currentIndex + 1] : null
+  };
+}
+
+// Function to get previous and next posts (without author)
+export function getAdjacentPostsNoAuthor(currentId: number) {
+  const sortedPosts = [...blogPostsNoAuthor].sort((a, b) => 
+    new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+  );
+  
+  const currentIndex = sortedPosts.findIndex(post => post.id === currentId);
+  
+  return {
+    previous: currentIndex > 0 ? sortedPosts[currentIndex - 1] : null,
+    next: currentIndex < sortedPosts.length - 1 ? sortedPosts[currentIndex + 1] : null
+  };
 } 

--- a/docs/how_to_switch_blog_card_models.md
+++ b/docs/how_to_switch_blog_card_models.md
@@ -1,0 +1,397 @@
+# How to Switch Between Blog Card Models
+
+This guide explains how to switch between blog post cards with author information and without author information in the DokaLab Blog project.
+
+## Overview
+
+The blog system supports two different card models:
+- **With Author Information**: Shows author avatar, name, and publication details
+- **Without Author Information**: Shows only post content, tags, and publication date
+
+## Prerequisites
+
+Before starting, ensure you have:
+- Basic understanding of file editing
+- Access to the project files
+- Text editor or IDE
+
+## Step-by-Step Guide
+
+### Step 1: Modify the Blog Page Data Source
+
+**File to edit**: `app/(global)/blog/page.tsx`
+
+#### 1.1 Change Import Statements
+
+**Find this code block** (around lines 1-18):
+```typescript
+import { 
+  /* COMPONENT SWAP GUIDE:
+   * Option 1: For data with author information
+   * blogPosts, 
+   * categoryGroups, 
+   * getCategoryById, 
+   * getPostsByCategoryId
+   *
+   * Option 2: For data without author information
+   * blogPostsNoAuthor, 
+   * categoryGroups, 
+   * getCategoryById, 
+   * getPostsNoAuthorByCategoryId
+   */
+  blogPosts, 
+  categoryGroups, 
+  getCategoryById, 
+  getPostsByCategoryId
+} from '@/app/data/blogData';
+```
+
+**To switch to WITHOUT author information, replace with**:
+```typescript
+import { 
+  /* COMPONENT SWAP GUIDE:
+   * Option 1: For data with author information
+   * blogPosts, 
+   * categoryGroups, 
+   * getCategoryById, 
+   * getPostsByCategoryId
+   *
+   * Option 2: For data without author information
+   * blogPostsNoAuthor, 
+   * categoryGroups, 
+   * getCategoryById, 
+   * getPostsNoAuthorByCategoryId
+   */
+  blogPostsNoAuthor, 
+  categoryGroups, 
+  getCategoryById, 
+  getPostsNoAuthorByCategoryId
+} from '@/app/data/blogData';
+```
+
+**To switch to WITH author information, replace with**:
+```typescript
+import { 
+  /* COMPONENT SWAP GUIDE:
+   * Option 1: For data with author information
+   * blogPosts, 
+   * categoryGroups, 
+   * getCategoryById, 
+   * getPostsByCategoryId
+   *
+   * Option 2: For data without author information
+   * blogPostsNoAuthor, 
+   * categoryGroups, 
+   * getCategoryById, 
+   * getPostsNoAuthorByCategoryId
+   */
+  blogPosts, 
+  categoryGroups, 
+  getCategoryById, 
+  getPostsByCategoryId
+} from '@/app/data/blogData';
+```
+
+#### 1.2 Update Type Comment
+
+**Find this code block** (around lines 25-35):
+```typescript
+/* COMPONENT SWAP GUIDE:
+ * Option 1: For data with author information
+ * import { BlogPost } from '@/app/types/blog';
+ *
+ * Option 2: For data without author information
+ * import { BlogPostNoAuthor } from '@/app/types/blog';
+ */
+// Note: The actual import is commented out as it's used indirectly through the BlogSearch component
+// Import will be needed when performing the swap
+// import { BlogPost } from '@/app/types/blog';
+```
+
+**To switch to WITHOUT author information, replace with**:
+```typescript
+/* COMPONENT SWAP GUIDE:
+ * Option 1: For data with author information
+ * import { BlogPost } from '@/app/types/blog';
+ *
+ * Option 2: For data without author information
+ * import { BlogPostNoAuthor } from '@/app/types/blog';
+ */
+// Note: The actual import is commented out as it's used indirectly through the BlogSearch component
+// Import will be needed when performing the swap
+// import { BlogPostNoAuthor } from '@/app/types/blog';
+```
+
+**To switch to WITH author information, replace with**:
+```typescript
+/* COMPONENT SWAP GUIDE:
+ * Option 1: For data with author information
+ * import { BlogPost } from '@/app/types/blog';
+ *
+ * Option 2: For data without author information
+ * import { BlogPostNoAuthor } from '@/app/types/blog';
+ */
+// Note: The actual import is commented out as it's used indirectly through the BlogSearch component
+// Import will be needed when performing the swap
+// import { BlogPost } from '@/app/types/blog';
+```
+
+#### 1.3 Update Tag Finding Logic
+
+**Find this code block** (around lines 60-67):
+```typescript
+    const tag = blogPosts.flatMap(post => post.tags).find(tag => tag.id === tagId);
+```
+
+**To switch to WITHOUT author information, replace with**:
+```typescript
+    const tag = blogPostsNoAuthor.flatMap(post => post.tags).find(tag => tag.id === tagId);
+```
+
+**To switch to WITH author information, replace with**:
+```typescript
+    const tag = blogPosts.flatMap(post => post.tags).find(tag => tag.id === tagId);
+```
+
+#### 1.4 Update Initial Posts Array
+
+**Find this code block** (around lines 85-92):
+```typescript
+  let filteredPosts = [...blogPosts];
+```
+
+**To switch to WITHOUT author information, replace with**:
+```typescript
+  let filteredPosts = [...blogPostsNoAuthor];
+```
+
+**To switch to WITH author information, replace with**:
+```typescript
+  let filteredPosts = [...blogPosts];
+```
+
+#### 1.5 Update Category Filtering Function
+
+**Find this code block** (around lines 105-112):
+```typescript
+      filteredPosts = getPostsByCategoryId(categoryId);
+```
+
+**To switch to WITHOUT author information, replace with**:
+```typescript
+      filteredPosts = getPostsNoAuthorByCategoryId(categoryId);
+```
+
+**To switch to WITH author information, replace with**:
+```typescript
+      filteredPosts = getPostsByCategoryId(categoryId);
+```
+
+### Step 2: Modify the Blog Search Component
+
+**File to edit**: `app/components/blog/BlogSearch.tsx`
+
+#### 2.1 Change Import Statements
+
+**Find this code block** (around lines 5-15):
+```typescript
+/* COMPONENT SWAP GUIDE:
+ * Option 1: For components with author information
+ * import { BlogPost } from '@/app/types/blog';
+ * import BlogPostCard from './BlogPostCard';
+ * 
+ * Option 2: For components without author information
+ * import { BlogPostNoAuthor } from '@/app/types/blog';
+ * import BlogPostCardNoAuthor from './BlogPostCardNoAuthor';
+ */
+import { BlogPost } from '@/app/types/blog';
+import BlogPostCard from './BlogPostCard';
+```
+
+**To switch to WITHOUT author information, replace with**:
+```typescript
+/* COMPONENT SWAP GUIDE:
+ * Option 1: For components with author information
+ * import { BlogPost } from '@/app/types/blog';
+ * import BlogPostCard from './BlogPostCard';
+ * 
+ * Option 2: For components without author information
+ * import { BlogPostNoAuthor } from '@/app/types/blog';
+ * import BlogPostCardNoAuthor from './BlogPostCardNoAuthor';
+ */
+import { BlogPostNoAuthor } from '@/app/types/blog';
+import BlogPostCardNoAuthor from './BlogPostCardNoAuthor';
+```
+
+**To switch to WITH author information, replace with**:
+```typescript
+/* COMPONENT SWAP GUIDE:
+ * Option 1: For components with author information
+ * import { BlogPost } from '@/app/types/blog';
+ * import BlogPostCard from './BlogPostCard';
+ * 
+ * Option 2: For components without author information
+ * import { BlogPostNoAuthor } from '@/app/types/blog';
+ * import BlogPostCardNoAuthor from './BlogPostCardNoAuthor';
+ */
+import { BlogPost } from '@/app/types/blog';
+import BlogPostCard from './BlogPostCard';
+```
+
+#### 2.2 Update Props Interface
+
+**Find this code block** (around lines 50-60):
+```typescript
+/* COMPONENT SWAP GUIDE:
+ * Option 1: For components with author information
+ * interface BlogSearchProps {
+ *   posts: BlogPost[];
+ *   categoryName?: string;
+ * }
+ *
+ * Option 2: For components without author information
+ * interface BlogSearchProps {
+ *   posts: BlogPostNoAuthor[];
+ *   categoryName?: string;
+ * }
+ */
+interface BlogSearchProps {
+  posts: BlogPost[];
+  categoryName?: string;
+}
+```
+
+**To switch to WITHOUT author information, replace with**:
+```typescript
+/* COMPONENT SWAP GUIDE:
+ * Option 1: For components with author information
+ * interface BlogSearchProps {
+ *   posts: BlogPost[];
+ *   categoryName?: string;
+ * }
+ *
+ * Option 2: For components without author information
+ * interface BlogSearchProps {
+ *   posts: BlogPostNoAuthor[];
+ *   categoryName?: string;
+ * }
+ */
+interface BlogSearchProps {
+  posts: BlogPostNoAuthor[];
+  categoryName?: string;
+}
+```
+
+**To switch to WITH author information, replace with**:
+```typescript
+/* COMPONENT SWAP GUIDE:
+ * Option 1: For components with author information
+ * interface BlogSearchProps {
+ *   posts: BlogPost[];
+ *   categoryName?: string;
+ * }
+ *
+ * Option 2: For components without author information
+ * interface BlogSearchProps {
+ *   posts: BlogPostNoAuthor[];
+ *   categoryName?: string;
+ * }
+ */
+interface BlogSearchProps {
+  posts: BlogPost[];
+  categoryName?: string;
+}
+```
+
+#### 2.3 Update Column Array Type
+
+**Find this code block** (around lines 110-117):
+```typescript
+    const columns = Array.from({ length: columnCount }, () => [] as BlogPost[]);
+```
+
+**To switch to WITHOUT author information, replace with**:
+```typescript
+    const columns = Array.from({ length: columnCount }, () => [] as BlogPostNoAuthor[]);
+```
+
+**To switch to WITH author information, replace with**:
+```typescript
+    const columns = Array.from({ length: columnCount }, () => [] as BlogPost[]);
+```
+
+#### 2.4 Update Card Component Usage
+
+**Find this code block** (around lines 250-270):
+```typescript
+                    <BlogPostCard
+                      post={post}
+                      featured={postIndex === 0 && columnIndex === 0}
+                    />
+```
+
+**To switch to WITHOUT author information, replace with**:
+```typescript
+                    <BlogPostCardNoAuthor
+                      post={post}
+                      featured={postIndex === 0 && columnIndex === 0}
+                    />
+```
+
+**To switch to WITH author information, replace with**:
+```typescript
+                    <BlogPostCard
+                      post={post}
+                      featured={postIndex === 0 && columnIndex === 0}
+                    />
+```
+
+## Quick Reference Table
+
+| Component | With Author | Without Author |
+|-----------|-------------|----------------|
+| Data Source | `blogPosts` | `blogPostsNoAuthor` |
+| Category Function | `getPostsByCategoryId` | `getPostsNoAuthorByCategoryId` |
+| Type | `BlogPost` | `BlogPostNoAuthor` |
+| Card Component | `BlogPostCard` | `BlogPostCardNoAuthor` |
+
+## Verification Steps
+
+After making the changes:
+
+1. **Check the blog page**: Navigate to `/blog` in your browser
+2. **Verify card appearance**: 
+   - With author: Should show author avatar and name at the bottom
+   - Without author: Should only show date and reading time
+3. **Test functionality**: Ensure search, filtering, and pagination still work
+4. **Check console**: Make sure there are no TypeScript errors
+
+## Common Issues
+
+### TypeScript Errors
+If you see TypeScript errors after switching:
+- Make sure ALL instances of the old type/component are replaced
+- Check that import statements match the component usage
+- Restart your development server if needed
+
+### Missing Author Information
+If cards appear broken:
+- Verify you're using the correct data source (`blogPosts` vs `blogPostsNoAuthor`)
+- Check that the card component matches the data type
+
+### Search Not Working
+If search functionality breaks:
+- Ensure the `BlogSearch` component props match the data type
+- Verify all array type declarations are consistent
+
+## Rollback Instructions
+
+To revert changes, simply follow the same steps but use the opposite configuration. The comment blocks in the code clearly indicate which option is currently active and which is the alternative.
+
+## Need Help?
+
+If you encounter issues:
+1. Check that all files have been modified consistently
+2. Verify there are no typos in the replaced code
+3. Ensure you've saved all files after making changes
+4. Restart the development server if problems persist 


### PR DESCRIPTION
이번 PR은 /blog route 하위의 페이지 스타일 개선 및 추가 페이지 추가에 대한 변경사항을 반영합니다.

## 1. 블로그 카드 플로팅 효과 제거
![image](https://github.com/user-attachments/assets/4a5f3b8c-6da4-4bf8-a165-a89b1f5f765b)
카드 hover 시 `translateY(-5px)` 효과를 제거하였습니다.

## 2. 게시글 본문 페이지 추가
![image](https://github.com/user-attachments/assets/a61d385d-7a9e-4bb0-8324-f3049d69c622)
프로토타입 형태입니다. 추후 변경 계획 수립하겠습니다.