### PR TITLE
feat(blog): improve blog post detail page navigation and layout

### DIFF
--- a/app/(global)/blog/post/[id]/page.module.scss
+++ b/app/(global)/blog/post/[id]/page.module.scss
@@ -261,18 +261,30 @@
   &:hover {
     border-color: #fda4af;
     box-shadow: 0 4px 12px rgba(253, 164, 175, 0.1);
-    transform: translateY(-2px);
+  }
+}
+
+.navCardDisabled {
+  background-color: #f8f9fa;
+  border-color: #e9ecef;
+  cursor: not-allowed;
+  opacity: 0.6;
+  
+  &:hover {
+    border-color: #e9ecef;
+    box-shadow: none;
   }
   
-  &:only-child {
-    grid-column: span 2;
-    max-width: 400px;
-    margin: 0 auto;
-    
-    @media (max-width: 768px) {
-      grid-column: span 1;
-      max-width: none;
-    }
+  .navDirection {
+    color: #adb5bd;
+  }
+  
+  .navTitle {
+    color: #6c757d;
+  }
+  
+  .navMeta {
+    color: #adb5bd;
   }
 }
 
@@ -300,29 +312,4 @@
 .navMeta {
   font-size: 0.8rem;
   color: #666;
-}
-
-// Back to Blog
-.backToBlog {
-  text-align: center;
-  padding-top: 2rem;
-  border-top: 1px solid #eee;
-}
-
-.backLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.5rem;
-  background-color: #f8f9fa;
-  color: #666;
-  text-decoration: none;
-  border-radius: 8px;
-  font-weight: 500;
-  transition: all 0.2s ease;
-  
-  &:hover {
-    background-color: #fda4af;
-    color: white;
-  }
 } 

--- a/app/(global)/blog/post/[id]/page.tsx
+++ b/app/(global)/blog/post/[id]/page.tsx
@@ -240,20 +240,6 @@ For further reading and deeper understanding, check out these resources:
             ))}
           </div>
         )}
-
-        {/* Cover Image */}
-        {post.coverImage && (
-          <div className={styles.coverImageContainer}>
-            <Image
-              src={post.coverImage}
-              alt={post.title}
-              fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 1200px"
-              className={styles.coverImage}
-              priority
-            />
-          </div>
-        )}
       </header>
 
       {/* Article Content */}
@@ -262,38 +248,43 @@ For further reading and deeper understanding, check out these resources:
       </article>
 
       {/* Navigation to Previous/Next Posts */}
-      {(previous || next) && (
-        <nav className={styles.postNavigation}>
-          <div className={styles.navigationGrid}>
-            {previous && (
-              <Link href={`/blog/post/${previous.id}`} className={styles.navCard}>
-                <div className={styles.navDirection}>← Previous</div>
-                <div className={styles.navTitle}>{previous.title}</div>
-                <div className={styles.navMeta}>
-                  {formatDate(previous.publishedAt)} • {previous.readingTime} min read
-                </div>
-              </Link>
-            )}
-            
-            {next && (
-              <Link href={`/blog/post/${next.id}`} className={styles.navCard}>
-                <div className={styles.navDirection}>Next →</div>
-                <div className={styles.navTitle}>{next.title}</div>
-                <div className={styles.navMeta}>
-                  {formatDate(next.publishedAt)} • {next.readingTime} min read
-                </div>
-              </Link>
-            )}
-          </div>
-        </nav>
-      )}
-
-      {/* Back to Blog Link */}
-      <div className={styles.backToBlog}>
-        <Link href="/blog" className={styles.backLink}>
-          ← Back to All Posts
-        </Link>
-      </div>
+      <nav className={styles.postNavigation}>
+        <div className={styles.navigationGrid}>
+          {/* Previous Post - Always show, either with content or as disabled */}
+          {previous ? (
+            <Link href={`/blog/post/${previous.id}`} className={styles.navCard}>
+              <div className={styles.navDirection}>← Previous</div>
+              <div className={styles.navTitle}>{previous.title}</div>
+              <div className={styles.navMeta}>
+                {formatDate(previous.publishedAt)} • {previous.readingTime} min read
+              </div>
+            </Link>
+          ) : (
+            <div className={`${styles.navCard} ${styles.navCardDisabled}`}>
+              <div className={styles.navDirection}>← Previous</div>
+              <div className={styles.navTitle}>No previous post</div>
+              <div className={styles.navMeta}>This is the first post</div>
+            </div>
+          )}
+          
+          {/* Next Post - Always show, either with content or as disabled */}
+          {next ? (
+            <Link href={`/blog/post/${next.id}`} className={styles.navCard}>
+              <div className={styles.navDirection}>Next →</div>
+              <div className={styles.navTitle}>{next.title}</div>
+              <div className={styles.navMeta}>
+                {formatDate(next.publishedAt)} • {next.readingTime} min read
+              </div>
+            </Link>
+          ) : (
+            <div className={`${styles.navCard} ${styles.navCardDisabled}`}>
+              <div className={styles.navDirection}>Next →</div>
+              <div className={styles.navTitle}>No next post</div>
+              <div className={styles.navMeta}>This is the latest post</div>
+            </div>
+          )}
+        </div>
+      </nav>
     </div>
   );
 } 


### PR DESCRIPTION
- Remove "Back to All Posts" button from bottom of post detail page
- Remove hover floating effects from previous/next post navigation cards
- Always display both previous and next navigation cards with disabled states when posts don't exist
- Remove automatic cover image display from article header, allowing pure user-controlled markdown content
- Add disabled styling for navigation cards with appropriate visual feedback
- Maintain consistent navigation positioning regardless of available posts

This update provides a more consistent and clean user experience for blog post navigation while giving users complete control over their article content presentation.