### PR TITLE
feat(blog): enhance breadcrumb navigation with home and blog links

### DIFF
--- a/app/(global)/blog/post/[id]/page.tsx
+++ b/app/(global)/blog/post/[id]/page.tsx
@@ -169,6 +169,14 @@ For further reading and deeper understanding, check out these resources:
     <div className={styles.container}>
       {/* Breadcrumb Navigation */}
       <nav className={styles.breadcrumb}>
+        <Link href="/" className={styles.breadcrumbLink}>
+          Home
+        </Link>
+        <span className={styles.breadcrumbSeparator}>&gt;</span>
+        <Link href="/blog" className={styles.breadcrumbLink}>
+          Blog
+        </Link>
+        <span className={styles.breadcrumbSeparator}>&gt;</span>
         {category && (
           <>
             <Link 


### PR DESCRIPTION
Add comprehensive breadcrumb navigation to blog post detail pages with proper hierarchical structure. Users can now easily navigate back to home page or blog listing page from individual post pages.

Changes:
- Add Home link pointing to root path (/)
- Add Blog link pointing to main blog listing (/blog)
- Maintain existing category and post title breadcrumb structure
- Improve user navigation experience with clear hierarchical path

The breadcrumb now displays: Home > Blog > Category > Post Title This provides better user orientation and easier navigation throughout the blog section.